### PR TITLE
Fix stefanstyletests

### DIFF
--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -241,7 +241,7 @@ sub evaluateTest {
 
 	my $status = 'failed';
 	if (-e "Truth/".$truth) {
-		# Replace concrete prefix file paths from executed test file with generic ROOTDIR and GAPDIR strings.
+		# Replace concrete prefix file paths from executed test file with generic ROOTDIR and BGAPDIR strings.
 		# Thus, recording truth on one system and testing at another should not result in different CMD lines.
 		# ToDo: Binaries are compiled in an arch dependent subdirectory, e.g. x86_64-linux-gnu, which will surely differ on systems like OSX!
 		Utils::execute(Settings::getBinary('cat')." $TMPDIR/$truth | ".Settings::getBinary('sed')." \"s#$Settings::rootDir#ROOTDIR#g\" | ".Settings::getBinary('sed')." \"s#$Settings::bgapDir#BGAPDIR#g\" > $TMPDIR/${truth}_noprefix");

--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -241,10 +241,12 @@ sub evaluateTest {
 
 	my $status = 'failed';
 	if (-e "Truth/".$truth) {
-		Utils::execute("cat $TMPDIR/$truth | sed \"s#$Settings::rootDir#ROOTDIR#g\" | sed \"s#$Settings::bgapDir#BGAPDIR#g\" > $TMPDIR/${truth}_noprefix");
-		#Utils::execute("cat Truth/$truth | sed \"s#/home/sjanssen/Desktop/fold-grammars/##g\" > Truth/${truth}_noprefix");
+		# Replace concrete prefix file paths from executed test file with generic ROOTDIR and GAPDIR strings.
+		# Thus, recording truth on one system and testing at another should not result in different CMD lines.
+		# ToDo: Binaries are compiled in an arch dependent subdirectory, e.g. x86_64-linux-gnu, which will surely differ on systems like OSX!
+		Utils::execute(Settings::getBinary('cat')." $TMPDIR/$truth | ".Settings::getBinary('sed')." \"s#$Settings::rootDir#ROOTDIR#g\" | ".Settings::getBinary('sed')." \"s#$Settings::bgapDir#BGAPDIR#g\" > $TMPDIR/${truth}_noprefix");
 
-		my $diffResult = Utils::execute("diff -I \"^Cluster info \(\" Truth/${truth} $TMPDIR/${truth}_noprefix"); chomp $diffResult;
+		my $diffResult = Utils::execute(Settings::getBinary('diff')." -I \"^Cluster info \(\" Truth/${truth} $TMPDIR/${truth}_noprefix"); chomp $diffResult;
 		if ($diffResult eq "") {
 			$status = 'passed';
 		} else {

--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -241,7 +241,10 @@ sub evaluateTest {
 
 	my $status = 'failed';
 	if (-e "Truth/".$truth) {
-		my $diffResult = Utils::execute("diff -I \"^#CMD:\" -I \"^Cluster info \(\" Truth/$truth $TMPDIR/$truth"); chomp $diffResult;
+		Utils::execute("cat $TMPDIR/$truth | sed \"s#$Settings::rootDir#ROOTDIR#g\" | sed \"s#$Settings::bgapDir#BGAPDIR#g\" > $TMPDIR/${truth}_noprefix");
+		#Utils::execute("cat Truth/$truth | sed \"s#/home/sjanssen/Desktop/fold-grammars/##g\" > Truth/${truth}_noprefix");
+
+		my $diffResult = Utils::execute("diff -I \"^Cluster info \(\" Truth/${truth} $TMPDIR/${truth}_noprefix"); chomp $diffResult;
 		if ($diffResult eq "") {
 			$status = 'passed';
 		} else {

--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -241,7 +241,7 @@ sub evaluateTest {
 
 	my $status = 'failed';
 	if (-e "Truth/".$truth) {
-		my $diffResult = Utils::execute("diff -I \"^#CMD:\" Truth/$truth $TMPDIR/$truth"); chomp $diffResult;
+		my $diffResult = Utils::execute("diff -I \"^#CMD:\" -I \"^Cluster info \(\" Truth/$truth $TMPDIR/$truth"); chomp $diffResult;
 		if ($diffResult eq "") {
 			$status = 'passed';
 		} else {

--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -280,6 +280,10 @@ sub printStatistics {
 		}
 	}
 	print "=" x ($maxLen+6+4)."\n";
+
+	if (@{$refList_failedTests} > 0) {
+		exit(1);
+	}
 }
 
 1;

--- a/Misc/Applications/lib/foldGrammars/Testing.pm
+++ b/Misc/Applications/lib/foldGrammars/Testing.pm
@@ -24,8 +24,8 @@ our @knotinframe_ALLMODES = ($Settings::MODE_KIF);
 our @pAliKiss_ALLMODES = ($Settings::MODE_MFE, $Settings::MODE_SUBOPT, $Settings::MODE_ENFORCE, $Settings::MODE_LOCAL, $Settings::MODE_SHAPES, $Settings::MODE_PROBS);
 
 our $pAliKiss = {
-	' ' => {	values => [$inputFileDir.'t-box.aln',$inputFileDir.'tRNA_example_ungap.aln',$inputFileDir.'trp_attenuator.aln'], 
-					secondValues => ["'.........................................(((...)))((((.....................................))))..........................................................................'","'(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).'","'.((....(((.((((.....)))).))).......))...............'"], 
+	' ' => {	values => [$inputFileDir.'t-box.aln',$inputFileDir.'tRNA_example_ungap.aln',$inputFileDir.'trp_attenuator.aln'],
+					secondValues => ["'.........................................(((...)))((((.....................................))))..........................................................................'","'(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).'","'.((....(((.((((.....)))).))).......))...............'"],
 					valueSelection => $VALUE_SELECTION_RANDOM,
 					modes => \@pAliKiss_ALLMODES},
 
@@ -56,8 +56,8 @@ our $pAliKiss = {
 };
 
 our $RNAalishapes = {
-	' ' => {	values => [$inputFileDir.'t-box.aln',$inputFileDir.'tRNA_example_ungap.aln',$inputFileDir.'trp_attenuator.aln'], 
-					secondValues => ["'.........................................(((...)))((((.....................................))))..........................................................................'","'(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).'","'.((....(((.((((.....)))).))).......))...............'"], 
+	' ' => {	values => [$inputFileDir.'t-box.aln',$inputFileDir.'tRNA_example_ungap.aln',$inputFileDir.'trp_attenuator.aln'],
+					secondValues => ["'.........................................(((...)))((((.....................................))))..........................................................................'","'(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).'","'.((....(((.((((.....)))).))).......))...............'"],
 					valueSelection => $VALUE_SELECTION_RANDOM,
 					modes => \@RNAalishapes_ALLMODES},
 
@@ -89,8 +89,8 @@ our $RNAalishapes = {
 };
 
 our $pKiss = {
-	' ' => {	values => ['ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA','AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU','gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC'], 
-					secondValues => ["'.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...'","'..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.'","'....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....'"], 
+	' ' => {	values => ['ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA','AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU','gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC'],
+					secondValues => ["'.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...'","'..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.'","'....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....'"],
 					valueSelection => $VALUE_SELECTION_RANDOM,
 					modes => \@pKiss_ALLMODES},
 
@@ -115,11 +115,11 @@ our $pKiss = {
 };
 
 our $RNAshapes = {
-	' ' => {	values => ['ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA','AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU','gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC'], 
-					secondValues => ["'.((((((((((((................))))))))))))........(((((((...)))))))...'","'..(((((....))))).....(((((((((.....))))))))).'","'.((.((.((((....)))).)))).....((((........)))).....'"], 
+	' ' => {	values => ['ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA','AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU','gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC'],
+					secondValues => ["'.((((((((((((................))))))))))))........(((((((...)))))))...'","'..(((((....))))).....(((((((((.....))))))))).'","'.((.((.((((....)))).)))).....((((........)))).....'"],
 					valueSelection => $VALUE_SELECTION_RANDOM,
 					modes => \@RNAshapes_ALLMODES},
-					
+
 	'mode' => {modes => \@RNAshapes_ALLMODES, values => \@RNAshapes_ALLMODES, valueSelection => $VALUE_SELECTION_ALL},
 	'windowSize' => {modes => [$Settings::MODE_MFE, $Settings::MODE_SUBOPT, $Settings::MODE_SHAPES, $Settings::MODE_PROBS, $Settings::MODE_SAMPLE], values => [undef, undef, 40, 100], valueSelection => $VALUE_SELECTION_ALL},
 	'windowIncrement' => {modes => [$Settings::MODE_MFE, $Settings::MODE_SUBOPT, $Settings::MODE_SHAPES, $Settings::MODE_PROBS, $Settings::MODE_SAMPLE], values => [10, 20, 30], valueSelection => $VALUE_SELECTION_RANDOM},
@@ -146,8 +146,8 @@ our $RNAshapes = {
 };
 
 our $Knotinframe = {
-	' ' => {	values => [$inputFileDir.'knotinframe_test.fas'], 
-					secondValues => [], 
+	' ' => {	values => [$inputFileDir.'knotinframe_test.fas'],
+					secondValues => [],
 					valueSelection => $VALUE_SELECTION_RANDOM,
 					modes => \@knotinframe_ALLMODES},
 
@@ -163,12 +163,12 @@ our $Knotinframe = {
 
 sub permutate {
 	my ($refHash_parameter, $refList_permutations) = @_;
-	
+
 	my @availParameters = ();
 	foreach my $param (sort {$a cmp $b} keys(%{$refHash_parameter})) {
 		push @availParameters, $param if ($refHash_parameter->{$param}->{valueSelection} eq $VALUE_SELECTION_ALL);
 	}
-	
+
 	if (@availParameters > 0) {
 		my @newPermutations = ();
 		my $parameter = $availParameters[0];
@@ -200,16 +200,16 @@ sub addRandomParameters {
 			if (Utils::contains($refHash_parameter->{$parameter}->{modes}, $refHash_call->{mode})) {
 				next if ((($parameter eq 'absoluteDeviation') && ($refHash_call->{call} =~ m/relativeDeviation/)) || (($parameter eq 'relativeDeviation') && ($refHash_call->{call} =~ m/absoluteDeviation/)));
 				my @values = @{$refHash_parameter->{$parameter}->{values}};
-				
+
 				if (exists $refHash_call->{allowLP}) {
 					@values = (1) if ($parameter eq 'absoluteDeviation' || $parameter eq 'relativeDeviation'); #otherwise tests will have to high runtime
 					@values = (0.01) if ($parameter eq 'lowProbFilter'); #otherwise tests will have to high runtime
 					@values = (5) if ($parameter eq 'shapeLevel');
 				}
-				
+
 				@values = (2) if ($parameter eq 'minHairpinLength' && $refHash_call->{mode} eq $Settings::MODE_ABSTRACT);
 				$refHash_call->{call} =~ s/--allowLP=1// if ($refHash_call->{mode} eq $Settings::MODE_CAST);
-				
+
 				my $randomIndex = int(rand scalar(@values));
 				my $value = $values[$randomIndex];
 				$value = substr($value, 0, 30) if (($parameter eq ' ') && ($refHash_call->{call} =~ m/\-\-mode=probing/)); #prevent too long sequences to avoid too large pareto fronts
@@ -238,7 +238,7 @@ sub addRandomParameters {
 
 sub evaluateTest {
 	my ($testname, $truth, $TMPDIR, $testIndex, $refList_failedTests) = @_;
-	
+
 	my $status = 'failed';
 	if (-e "Truth/".$truth) {
 		my $diffResult = Utils::execute("diff -I \"^#CMD:\" Truth/$truth $TMPDIR/$truth"); chomp $diffResult;
@@ -250,36 +250,36 @@ sub evaluateTest {
 	} else {
 		print "truth file 'Truth/$truth' does not exist!\n";
 	}
-	
+
 	if ($status eq 'passed') {
 		print "==-== test ".$testIndex.") '".$testname."' PASSED ==-==\n\n";
 	} else {
 		print "==-== test ".$testIndex.") '".$testname."' FAILED ==-==\n\n";
 		push @{$refList_failedTests}, $testname;
 	}
-	
+
 	$testIndex++;
-	
+
 	return $testIndex;
 }
 
 sub printStatistics {
 	my ($testIndex, $refList_failedTests) = @_;
-	
+
 	my $maxLen = 30;
 	foreach my $test (@{$refList_failedTests}) {
 		$maxLen = length($test) if (length($test) > $maxLen);
 	}
-	
-	print "=" x ($maxLen+6+4)."\n";	
+
+	print "=" x ($maxLen+6+4)."\n";
 	print "|| PASSED: ".sprintf("% 3i", $testIndex-1-scalar(@{$refList_failedTests}))."     |   FAILED: ".sprintf("% 3i", scalar(@{$refList_failedTests})).(" " x ($maxLen - 26))."||\n";
 	if (@{$refList_failedTests} > 0) {
-		print "|| follwing tests failed:".(" " x ($maxLen-17))."||\n";  
+		print "|| follwing tests failed:".(" " x ($maxLen-17))."||\n";
 		foreach my $testname (@{$refList_failedTests}) {
 			print "|| - '$testname'".(" " x ($maxLen-length($testname)+1))."||\n";
 		}
 	}
-	print "=" x ($maxLen+6+4)."\n";	
+	print "=" x ($maxLen+6+4)."\n";
 }
 
 1;

--- a/Misc/Test-Suite/StefanStyle/Truth/knotinframe.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/knotinframe.run.out
@@ -1,4 +1,4 @@
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-10 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=17 --windowincrement=40 --windowsize=120
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-10 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=17 --windowincrement=40 --windowsize=120
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT
@@ -31,7 +31,7 @@
   -11.63  ...(((...)))...((((...(((((...((...))...)))))........))))...  nested structure
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-7.4 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=5 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=160
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-7.4 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=5 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=160
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT
@@ -64,7 +64,7 @@
    -8.84  ...........((.((....(((((.....((...))....)))))......)).))...  nested structure
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-5 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=5 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=17 --windowincrement=20 --windowsize=80
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-8.71 --minknottedenergy=-5 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=5 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=17 --windowincrement=20 --windowsize=80
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT
@@ -97,7 +97,7 @@
   -11.63  ...(((...)))...((((...(((((...((...))...)))))........))))...  nested structure
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-10 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=80
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-10 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=80
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT
@@ -130,7 +130,7 @@
    -8.84  ...........((.((....(((((.....((...))....)))))......)).))...  nested structure
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-7.4 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=37 --windowincrement=20 --windowsize=160
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-7.4 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=37 --windowincrement=20 --windowsize=160
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT
@@ -163,7 +163,7 @@
    -6.20  ...........((.((....(((((................)))))......)).))...  nested structure
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-5 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=120
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/knotinframe  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=kif --minenergydifference=-10.34 --minknottedenergy=-5 ROOTDIR/Misc/Test-Suite/StefanStyle/knotinframe_test.fas --numberoutputs=15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9 --windowincrement=20 --windowsize=120
 >pol_m_vir_hastr
   Rank:              1
   Slippery sequence: CCCTTTT

--- a/Misc/Test-Suite/StefanStyle/Truth/palikiss.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/palikiss.run.out
@@ -1,19 +1,19 @@
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=1.1 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=1.1 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=37 --windowIncrement=10
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-44.40 = -34.15 + -10.25)  (((((((...........[[.........{{{{{]].....}}}}}.....(((((.......)))))))))))).  (sci:  0.440)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-20 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-20 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-85.73 = -79.23 + -6.50)  ............[[.{{{{....]]..........<<.}}}}..>>....[[.{{]]......<<<.}}..>>>...................[[..{{]].....}}.............................................................  (sci:  0.460)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-53.33 = -45.59 + -7.74)  .[[[[[.{{.]]]]]...}}[[.{{.]].......}}...
 
                        21  rGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-25.49 = -21.40 + -4.09)  [[.{{.]]................}}......
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=10
                        1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-40.17 = -41.09 + 0.92)  ....................[[[..{{...]]]..[[.....{{]]...}}...}}............................................  (sci:  0.310)
 
@@ -38,34 +38,34 @@
                       71  rGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (  0.00 =   0.00 + 0.00)  ...................................................................................................  (sci: 0.000)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
-                       1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
+                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-36.93 = -37.03 + 0.10)  ..........................................[[[.{{]]].[[.{{....................................]]....}}..(...............................................)...}}............  (sci:  0.180)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-95.44 = -85.70 + -9.74)  ...........[[.{{{]]..<<.}}}...>>...[[.....{{]]...}}[[.{{]]...<<<}}.....>>>..................[[[..{{]]]....}}...........................[[........{{....]].........}}.....
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-15 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=30
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-15 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=30
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 (-23.80 = -21.56 + -2.24)  ...........[[.{{.]][[..{{]]....}}.....}}  (sci:  0.580)
 
-                       31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg  70
+                       31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG  70
 (-42.19 = -33.71 + -8.48)  .....[[.....{{]]...}}[[[.{{......]]]..}}  (sci:  0.860)
 
-                       61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                       61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-13.95 = -10.97 + -2.98)  ...[[......................{{....]]..}}.  (sci:  0.470)
 
-                       91  g_ucguccccgcgccugg________________g_u___  130
+                       91  G_UCGUCCCCGCGCCUGG________________G_U___  130
 (-18.42 = -16.47 + -1.95)  ..[[[..{{]]]....}}......................  (sci:  0.540)
 
-                      121  ____g_u________cuggg_____gcccgaggagaca__  160
+                      121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 (  0.00 =   0.00 +  0.00)  ........................................  (sci: 0.000)
 
-                      151  aggagaca__acgcg____  169
+                      151  AGGAGACA__ACGCG____  169
 (  0.00 =   0.00 +  0.00)  ...................  (sci: 0.000)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=25.9 --windowIncrement=20
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-82.41 = -71.59 + -10.82)  ..............[[[[..{{.]]]]....}}..[[.....{{]]...}}[[[.{{......]]]..}}.[[[.............{{....]]]..}}  (sci:  0.720)
 
@@ -81,48 +81,48 @@
                         81  -----u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-28.66 = -25.90 +  -2.76)  .......[[....{{..]]..}}[[........................................{{....]].........}}.....  (sci:  0.360)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=10
-                          1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=10
+                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-102.35 = -91.08 + -11.27)  ..............[[[...{{..]]]....}}..[[.{{{{..]]...}}}}.[[......{{]].....}}..............[[....{{..]]..}}[[........................................{{....]].........}}.....  (sci:  0.570)
 (-102.25 = -90.26 + -11.99)  ..............[[[...{{..]]]....}}..[[.{{{{..]]...}}}}[[........{{{.]]..}}}.............[[....{{..]]..}}[[........................................{{....]].........}}.....  (sci:  0.570)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=P --temperature=25.9 --windowIncrement=30
-                       1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=P --temperature=25.9 --windowIncrement=30
+                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-36.85 = -37.43 + 0.58)  .....................[[.{{....]]...[[..{{{{{]]....[[.{{........]]...........................}}..}}}}}..}}................................................................
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 (-20.13 = -18.84 + -1.29)  ...........[[.{{.]][[..{{]]....}}.....}}  (sci:  0.570)
 
-                       21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                       21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 (-35.57 = -30.86 + -4.71)  [[[..{{...]]].....}}..[[[.{{]]]...}}....  (sci:  0.880)
 
-                       41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                       41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 (-27.91 = -23.74 + -4.17)  ..[[[.{{]]][[.{{]]......}}.....}}.......  (sci:  0.790)
 (-26.96 = -23.37 + -3.59)  ..[[[.{{]]][[.{{]]....}}.......}}.......  (sci:  0.760)
 (-26.93 = -23.82 + -3.11)  .[[..{{{.]][[.{{]]....}}..}}}...........  (sci:  0.760)
 
-                       61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                       61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-12.27 = -10.06 + -2.21)  ...[[......................{{....]]..}}.  (sci:  0.470)
 (-11.98 =  -9.87 + -2.11)  ...[[......................{{....]]...}}  (sci:  0.460)
 (-11.60 = -11.37 + -0.23)  ....[[.....{{]]...................}}....  (sci:  0.440)
 (-11.48 = -10.82 + -0.66)  ...........[[[.............{{....]]]..}}  (sci:  0.440)
 (-11.44 = -10.92 + -0.52)  ............[[.............{{]]......}}.  (sci:  0.440)
 
-                       81  _______ggcg_ucguccccgcgccugg____________  120
+                       81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 (-15.03 = -13.52 + -1.51)  .............[[..{{]].....}}............  (sci:  0.550)
 (-14.88 = -13.37 + -1.51)  .............[[.{{.]].....}}............  (sci:  0.550)
 
-                      101  gcgccugg________________g_u________cuggg  140
+                      101  GCGCCUGG________________G_U________CUGGG  140
 (  0.00 =   0.00 +  0.00)  ........................................  (sci: 0.000)
 
-                      121  ____g_u________cuggg_____gcccgaggagaca__  160
+                      121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 (  0.00 =   0.00 +  0.00)  ........................................  (sci: 0.000)
 
-                      141  _____gcccgaggagaca__acgcg____  169
+                      141  _____GCCCGAGGAGACA__ACGCG____  169
 (  0.00 =   0.00 +  0.00)  .............................  (sci: 0.000)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=37 --windowIncrement=20
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-77.41 = -68.53 + -8.88)  ..............[[[[..{{{]]]]...}}}..[[.....{{]]...}}[[[.{{......]]]..}}..[[.............{{]]......}}.  (sci:  0.720)
 (-77.37 = -68.30 + -9.07)  ..............[[[[..{{{]]]]...}}}..[[.....{{]]...}}[[[.{{......]]]..}}.[[[.............{{....]]]..}}  (sci:  0.720)
@@ -158,17 +158,17 @@
 (-33.30 = -31.00 + -2.30)  .............[[..{{]].....}}.............................[[......{{]].............}}.....  (sci:  0.450)
 (-33.15 = -30.85 + -2.30)  .............[[.{{.]].....}}.............................[[......{{]].............}}.....  (sci:  0.440)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-55.24 = -43.49 + -11.75)  .[[[[[.{{{{{{{]]]]]..}}}}}}}........[[..{{]]......}}  (sci:  1.070)
 (-54.32 = -43.44 + -10.88)  .[[[[.{{{{{{{{.]]]]..}}}}}}}}.......[[..{{]]......}}  (sci:  1.050)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-58.64 = -44.45 + -14.19)  .[[.{{.[[[[[[[.....{{]]]]]]]........}}.]]...}}......  (sci:  0.850)
 (-58.53 = -43.90 + -14.63)  .[[.{{.[[[[[[[.{{....]]]]]]]........}}.]]...}}......  (sci:  0.850)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-38.30 = -38.44 +  0.14)  ....[[.[[...{{]].....}}{{.]].......}}...
 (-37.94 = -38.28 +  0.34)  .[[...[[[...{{]]]....}}{{.]].......}}...
@@ -181,26 +181,26 @@
 (-16.92 = -16.84 + -0.08)  ...[[...........{{......]]....}}
 (-16.70 = -16.57 + -0.13)  ....[[..........{{...]].......}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
-                       1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
+                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-46.06 = -47.34 + 1.28)  .[[.[[[[[..{{{]]]]]..}}}{{]]......}}[[..{{]]......}}  (sci:  0.770)
 (-45.96 = -47.61 + 1.65)  [[[.[[[[[..{{{]]]]]..}}}{{]]].....}}[[..{{]]......}}  (sci:  0.770)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1.1 --consensus=mis --minHairpinLength=2 --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --strategy=B --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1.1 --consensus=mis --minHairpinLength=2 --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --strategy=B --temperature=25.9 --windowIncrement=10
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-27.24 = -13.93 + -13.31)  ......................................((((((.......((((((.....((((.....))))..............)).))))))))))...................................................................  best 'nested structure'
 (-98.19 = -86.32 + -11.87)  ..............[[[...{{..]]]....}}..[[.{{{{..]]...}}}}[[.......{{{{.]]..}}}}............[[....{{..]]..}}[[........................................{{....]].........}}.....  best 'H-type pseudoknot'
 (-78.03 = -65.36 + -12.67)  ............[[.{{{{....]]......<<.....}}}}[[.{{{.]]...........<<<<}}}..>>>>..............>>..[[..{{]]............................................<<....}}.........>>.....  best 'K-type pseudoknot'
 (-99.74 = -87.55 + -12.19)  ..............[[[...{{..]]]....}}..[[.....{{]]...}}[[[.{{......]]]..}}..[[.............{{]]..<<<.}}.>>>[[........................................{{....]].........}}.....  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=0.9 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --strategy=P --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --cfactor=0.9 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --strategy=P --temperature=17 --windowIncrement=30
                            1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( -28.97 =  -16.85 + -12.12)  .............(((...((....))...........((((((.......((((((.....((((.....))))..............)).))))))))))...........................................))).....................  (sci:  0.140)  best 'nested structure'
 (-116.53 = -108.53 +  -8.00)  ...........[[.{{{]].....}}}...[[...[[.....{{]]...}}{{{]].....}}}[[.....{{]]............[[[..{{[[.{{{]]...................................}}}.....]]]....}}........}}.....  (sci:  0.550)  best 'H-type pseudoknot'
                               no structure available                                                                                                                                                     (sci: 0.000)  best 'K-type pseudoknot'
                               no structure available                                                                                                                                                     (sci: 0.000)  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --strategy=C --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --strategy=C --temperature=25.9 --windowIncrement=20
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 (  0.00 =   0.00 +  0.00)  ........................................  best 'nested structure'
 (-22.99 = -20.62 + -2.37)  ..............[[.{{]].................}}  best 'H-type pseudoknot'
@@ -249,46 +249,46 @@
                            no structure available         best 'K-type pseudoknot'
                            no structure available         best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1 --consensus=consensus --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=B --temperature=37 --windowIncrement=30
-                     1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1 --consensus=consensus --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=B --temperature=37 --windowIncrement=30
+                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-0.71 = -0.85 + 0.14)  ..........................................((.....)).................................................  best 'nested structure'
                         no structure available                                                                                best 'H-type pseudoknot'
                         no structure available                                                                                best 'K-type pseudoknot'
                         no structure available                                                                                best 'H- and K-type pseudoknot'
 
-                    31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                    31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-0.71 = -0.85 + 0.14)  ............((.....))...............................................................................  best 'nested structure'
                         no structure available                                                                                best 'H-type pseudoknot'
                         no structure available                                                                                best 'K-type pseudoknot'
                         no structure available                                                                                best 'H- and K-type pseudoknot'
 
-                    61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                    61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 + 0.00)  ....................................................................................................  best 'nested structure'
                         no structure available                                                                                best 'H-type pseudoknot'
                         no structure available                                                                                best 'K-type pseudoknot'
                         no structure available                                                                                best 'H- and K-type pseudoknot'
 
-                    91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                    91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 + 0.00)  ...............................................................................  best 'nested structure'
                         no structure available                                                           best 'H-type pseudoknot'
                         no structure available                                                           best 'K-type pseudoknot'
                         no structure available                                                           best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=A --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=A --temperature=17 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-12.91 = -13.02 +  0.11)  .......(((.((((.....)))).)))........................  best 'nested structure'
 (-43.17 = -42.91 + -0.26)  .[[[[[.....{{{]]]]]..}}}[[..........{{...]].......}}  best 'H-type pseudoknot'
 (-39.03 = -39.82 +  0.79)  .[[[[..{{{.]]]].......<<<}}}.......>>>..............  best 'K-type pseudoknot'
 (-47.59 = -47.38 + -0.21)  [[.{{.]]...<<<<}}...>>>>[[..........{{...]].......}}  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=C --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=C --temperature=37 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 ( -6.63 =  -6.56 + -0.07)  .......((..((((.....))))..))........................  (sci:  0.100)  best 'nested structure'
 (-42.56 = -42.30 + -0.26)  ....[[.[[..{{{]].....}}}{{]].............}}.........  (sci:  0.610)  best 'H-type pseudoknot'
                            no structure available                                (sci: 0.000)  best 'K-type pseudoknot'
                            no structure available                                (sci: 0.000)  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=4 --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --strategy=P --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --minHairpinLength=4 --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --strategy=P --temperature=37 --windowIncrement=30
                          1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-22.51 = -11.10 + -11.41)  .......((((((((.....))))))))............  (sci:  0.540)  best 'nested structure'
 (-42.90 = -29.75 + -13.15)  .[[[[[.{{{{{{{]]]]]..}}}}}}}............  (sci:  1.030)  best 'H-type pseudoknot'
@@ -301,34 +301,34 @@
                             no structure available  (sci: 0.000)  best 'K-type pseudoknot'
                             no structure available  (sci: 0.000)  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=P --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=P --temperature=17 --windowIncrement=10
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-38.73 = -29.57 + -9.16)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.350)  best 'nested structure'
 (-63.41 = -58.95 + -4.46)  ........[[.........((.....))..{{{{]].....}}}}[[....{{{{{]].....}}}}}........  (sci:  0.570)  best 'H-type pseudoknot'
                            no structure available                                                        (sci: 0.000)  best 'K-type pseudoknot'
                            no structure available                                                        (sci: 0.000)  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --strategy=P --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --strategy=P --temperature=37 --windowIncrement=10
 === window: 1 to 76: ===
-                         5  gcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgc  75
+                         5  GCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGC  75
 (-77.00 = -53.75 + -23.25)  [[[..{{.......[[...[[....{{{{{]].....}}}}}.....{{{{{.]]....}}}}}]]]..}}
 (-76.07 = -53.48 + -22.59)  [[[..{{.......[[.....[[..{{{{{.]]....}}}}}.....{{{{{.]]....}}}}}]]]..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=A --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=A --temperature=25.9 --windowIncrement=30
 === window: 1 to 169: ===
                          16  MYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYR  163
 (-103.14 = -90.87 + -12.27)  [[.{{[[...{{....]].....}}]][[[.{{]]][[.[[......{{]].....}}...................{{]][[[.{{...................................]]].....}}..}}....}}....}}  (sci:  0.560)
 (-102.35 = -90.32 + -12.03)  [[.{{[[...{{....]].....}}]][[[.{{]]][[.[[[....{{]]].......................}}.{{]][[[.{{...................................]]].....}}..}}....}}....}}  (sci:  0.550)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=B --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=B --temperature=25.9 --windowIncrement=30
 === window: 1 to 40: ===
-                         3  gugguggcccgcucaaccggcggccca______cu  37
+                         3  GUGGUGGCCCGCUCAACCGGCGGCCCA______CU  37
 (-51.10 = -41.04 + -10.06)  [[[[.{{{{{{.]]]]..<<}}}}}}.......>>  (sci:  1.040)
 
-                         4  ugguggcccgcucaaccggcggccca______cug  38
+                         4  UGGUGGCCCGCUCAACCGGCGGCCCA______CUG  38
 (-50.84 = -40.95 +  -9.89)  [[[.{{{{{{.]]]..<<<}}}}}}.......>>>  (sci:  1.050)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=C --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --maxKnotSize=40 --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --strategy=C --temperature=17 --windowIncrement=30
 === window: 1 to 76: ===
                         33  GSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVD  72
 (-46.23 = -34.77 + -11.46)  [[..{{...]].[[[....{{{{{]]]....}}}}}..}}  (sci:  0.960)
@@ -337,9 +337,9 @@
                         27  GCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCY  66
 (-45.75 = -34.34 + -11.41)  [[.[[[[[..{{...]]]]].....}}{{]].......}}  (sci:  0.920)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=B --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=B --temperature=25.9 --windowIncrement=10
 === window: 1 to 169: ===
-                       43  ggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagac  157
+                       43  GGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGAC  157
 (-20.05 = -20.20 +  0.15)  [[[.{{]]].(((.....................................)))....(.............................................).........}}  (sci:  0.150)
 (-20.00 = -20.27 +  0.27)  [[[.{{]]].(............................................................................................).........}}  (sci:  0.150)
 (-19.87 = -20.10 +  0.23)  [[[.{{]]]((((.....................................))))...(.............................................).........}}  (sci:  0.150)
@@ -353,50 +353,50 @@
 (-19.08 = -19.10 +  0.02)  [[[.{{]]].((((..................................).))).....(...............................................)......}}  (sci:  0.140)
 (-19.08 = -19.38 +  0.30)  [[[.{{]]].((((..................................).))).(................................................).........}}  (sci:  0.140)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=D --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --strategy=D --temperature=37 --windowIncrement=20
 === window: 1 to 76: ===
                         7  GURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVD  72
 (-58.83 = -54.26 + -4.57)  [[...{{......]]..[[.....{{{{]].....}}}}[[....{{{{{]].....}}}}}..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=D --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=4 --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=D --temperature=17 --windowIncrement=10
 === window: 21 to 60: ===
-                      36  caagcggggugguacc  51
+                      36  CAAGCGGGGUGGUACC  51
 (-22.20 = -22.48 + 0.28)  [[.....{{]]...}}  (sci:  0.860)
 (-22.11 = -22.45 + 0.34)  [[....{{.]]...}}  (sci:  0.860)
 
-                      40  cggggugguacc  51
+                      40  CGGGGUGGUACC  51
 (-21.52 = -21.67 + 0.15)  [[.{{]]...}}  (sci:  1.120)
 
 === window: 31 to 70: ===
-                      36  caagcggggugguacc  51
+                      36  CAAGCGGGGUGGUACC  51
 (-22.20 = -22.48 + 0.28)  [[.....{{]]...}}  (sci:  0.860)
 (-22.11 = -22.45 + 0.34)  [[....{{.]]...}}  (sci:  0.860)
 
-                      40  cggggugguacc  51
+                      40  CGGGGUGGUACC  51
 (-21.52 = -21.67 + 0.15)  [[.{{]]...}}  (sci:  1.120)
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=C --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=4 --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --strategy=C --temperature=37 --windowIncrement=10
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-12 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=consensus --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-59.62 = -46.93 + -12.69)  .[[.[[[[[..{{{]]]]]..}}}{{]]........<<...}}.......>>  [[{]}{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-27.29 = -27.52 +  0.23)  ...................................[[.....{{]]...}}......................................................................................................................  (sci:  0.130)  [{]}
 (-27.26 = -27.48 +  0.22)  ...................................[[.....{{]]...}}.(((.....................................)))..........................................................................  (sci:  0.130)  [{]}()
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=2 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=10
-                        1  uggugguggcccgcucaaccggcggccca______cugau  40
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=2 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=10
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-24.38 = -24.27 + -0.11)  ....[[.{{....]].......<<..}}........>>..  [{]<}>
 
-                       11  ccgcucaaccggcggccca______cugauugcgccuuuu  50
+                       11  CCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUU  50
 (-20.05 = -20.07 +  0.02)  .[[[.....{{]]]................}}........  [{]}
 
-                       21  ggcggccca______cugauugcgccuuuuug  52
+                       21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-11.92 = -11.82 + -0.10)  ...[[...........{{......]]....}}  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --minHairpinLength=6 --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
                        1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-31.07 = -32.14 + 1.07)  ...........[[....{{..[[..{{...]]...[[.....{{]]...}}...}}........]]............................}}....  (sci:  0.310)  [{[{][{]}}]}
 
@@ -412,37 +412,37 @@
                       81  -----u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (  0.00 =   0.00 + 0.00)  .........................................................................................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --minHairpinLength=4 --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=30
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --minHairpinLength=4 --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=30
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-23.07 = -23.14 +  0.07)  ..........................................[[[.{{]]].(((.....................................)))....(.............................................).........}}............  (sci:  0.110)  [{]()()}
 (-22.45 = -22.66 +  0.21)  ..........................................[[[.{{]]].(............................................................................................).........}}............  (sci:  0.110)  [{]()}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-92.48 = -71.41 + -21.07)  ......[[.{{{..]]..}}}..[[....{{{{{]].....}}}}}.....[[[[[..{{...]]]]]....}}..  (sci:  0.910)  [{]}[{]}[{]}
 (-92.21 = -62.75 + -29.46)  (((((((.[[.[[.{{..]]......}}.{{{{{.]]....}}}}}...[[.{{{{...]]..}}}}.))))))).  (sci:  0.910)  ([[{]}{]}[{]})
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --minHairpinLength=6 --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 (-26.77 = -25.50 + -1.27)  .........[[[......{{{....]]].....}}}....  [{]}
 
-                       31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                       31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-36.86 = -31.96 + -4.90)  ((((.......))))[[....{{{{{]].....}}}}}..  ()[{]}
 
-                       61  aaucccaucgaacgcg  76
+                       61  AAUCCCAUCGAACGCG  76
 (  0.00 =   0.00 +  0.00)  ................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --cfactor=1 --consensus=mis --maxKnotSize=40 --minHairpinLength=2 --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-81.80 = -62.41 + -19.39)  ......[[.{{{..]]..}}}..[[....{{{{{]].....}}}}}.....[[[[[..{{...]]]]]....}}..  (sci:  0.920)  [{]}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
                           1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-101.50 = -80.43 + -21.07)  ......[[.{{{..]]..}}}..[[....{{{{{]].....}}}}}.....[[[[[..{{...]]]]]....}}..  (sci:  0.950)  0.9995455  [{]}[{]}[{]}
 ( -96.08 = -80.44 + -15.64)  [[...{{..]][[.{{..]]......}}..}}[[.{{....]]...}}...[[[[[..{{...]]]]]....}}..  (sci:  0.900)  0.0004545  [{][{]}}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-12 --Kpenalty=-15 --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-88.84 = -78.01 + -10.83)  ..............[[[...{{..]]]....}}..[[.{{{{..]]...}}}}.[[......{{]].....}}....................[[..{{]].....}}.............................................................  (sci:  0.490)  0.9610364  [{]}[{]}[{]}[{]}
 (-86.23 = -74.52 + -11.71)  ..............[[[...{{..]]]....}}..[[.{{{{..]]...}}}}.[[......{{]].....}}....................[[..{{]].....}}.....................................((...............)).....  (sci:  0.480)  0.0389636  [{]}[{]}[{]}[{]}()
 (-57.95 = -47.77 + -10.18)  ...........((([[[...{{..]]]....}}..[[.{{{{..]]...}}}}..........)))...........................[[..{{]].....}}.............................................................  (sci:  0.320)  0.0000000  ([{]}[{]})[{]}
@@ -450,43 +450,43 @@
 (-55.34 = -44.28 + -11.06)  ...........((([[[...{{..]]]....}}..[[.{{{{..]]...}}}}..........)))...........................[[..{{]].....}}.....................................((...............)).....  (sci:  0.310)  0.0000000  ([{]}[{]})[{]}()
 (-56.58 = -45.58 + -11.00)  ...........(((....[[[....{{........[[.....{{]]...}}]]]..}}.....)))...........................[[..{{]].....}}.............................................................  (sci:  0.310)  0.0000000  ([{[{]}]})[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=2 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=10
-                        1  uggugguggcccgcucaaccggcggccca______cugau  40
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=2 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=10
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-42.54 = -42.98 +  0.44)  .[[.{{[[[..{{{]]]....}}}..]].......}}...  0.98  [{[{]}]}
 (-41.01 = -41.16 +  0.15)  ....[[.[[...{{]].....}}{{.]].......}}...  0.02  [[{]}{]}
 
-                       11  ccgcucaaccggcggccca______cugauugcgccuuuu  50
+                       11  CCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUU  50
 (-25.54 = -25.56 +  0.02)  .[[[.....{{]]]................}}........  1.00  [{]}
 
-                       21  ggcggccca______cugauugcgccuuuuug  52
+                       21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-19.02 = -18.97 + -0.05)  [[..{{.........]]....}}.........  1.00  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=4 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=30
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --Hpenalty=-15 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=4 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=30
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-96.08 = -88.90 + -7.18)  ...........[[.{{.]][[..{{]]....}}.....}}.[[..{{{.]][[.{{]]....}}..}}}..[[[.............{{....]]]..}}  (sci:  0.750)  0.9828708  [{][{]}}[{][{]}}[{]}
 
-                       31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                       31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-78.63 = -68.74 + -9.89)  .....[[.{{{{..]]...}}}}[[.......{{{{.]]..}}}}..................[[..{{]].....}}......................  (sci:  0.660)  1.0000000  [{]}[{]}[{]}
 
-                       61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                       61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 (-24.23 = -21.23 + -3.00)  ..((((.....))))..................[[..{{]].....}}....................................................  (sci:  0.230)  0.9512897  ()[{]}
 
-                       91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                       91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-22.23 = -20.29 + -1.94)  ...[[..{{]].....}}.............................................................  (sci:  0.270)  0.9405870  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --nfactor=1.1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-74.91 = -57.88 + -17.03)  ......[[.{{{..]]..}}}..[[....{{{{{]].....}}}}}.....[[[[[..{{...]]]]]....}}..  (sci:  0.980)  1.00  [{]}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-20 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --minHairpinLength=2 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=10
-                        1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --Hpenalty=-15 --Kpenalty=-20 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --minHairpinLength=2 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=10
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-52.99 = -52.83 + -0.16)  ....[[.[[..{{{]].....}}}{{]]........<<...}}.......>>  0.9999992  [[{]}{]<}>
 (-45.22 = -44.75 + -0.47)  ...[[[.....{{{]]]....}}}[[..........{{...]].......}}  0.0000004  [{]}[{]}
 (-44.79 = -44.52 + -0.27)  .[[.{{.[[..{{{]].....}}}...........]].......}}......  0.0000004  [{[{]}]}
 (-42.84 = -42.70 + -0.14)  .[[.{{.[[..{{{]].....}}}...(.........).]]...}}......  0.0000000  [{[{]}()]}
 (-42.23 = -41.85 + -0.38)  .[[...[[[..{{{]]]....}}}{{.........]]....}}.........  0.0000000  [[{]}{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1 --consensus=mis --lowProbFilter=0.01 --minHairpinLength=2 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-12 --Kpenalty=-12 --cfactor=1 --consensus=mis --lowProbFilter=0.01 --minHairpinLength=2 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=20
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 (-36.27 = -31.46 + -4.81)  [[....{{.]]...}}...[[..{{.]]......}}....  (sci:  0.840)  1.0000000  [{]}[{]}
 
@@ -500,8 +500,8 @@
                        41  MSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-36.04 = -26.59 + -9.45)  ....[[[....{{{{{]]]....}}}}}........  (sci:  0.910)  0.9999987  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --minHairpinLength=6 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=10
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pAliKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --Hpenalty=-9 --Kpenalty=-12 --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --minHairpinLength=6 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=10
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-57.56 = -48.42 + -9.14)  (((((((...........[[....[[[..{{{{{]]]....}}}}}.....{{{{{.]]....}}}}}))))))).  0.83  ([[{]}{]})
 (-56.22 = -46.93 + -9.29)  (((((((..((...))..[[....[[[..{{{{{]]]....}}}}}.....{{{{{.]]....}}}}}))))))).  0.17  (()[[{]}{]})
 

--- a/Misc/Test-Suite/StefanStyle/Truth/pkiss.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/pkiss.run.out
@@ -1,14 +1,14 @@
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -71.40  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -70.50  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -62.56  [[[.[[.[[.{{]]..}}{{]]..}}.{{{]]]....}}}
@@ -16,22 +16,22 @@
     31  CCCAGCUACUCGGGAGGCUC  50
 -26.41  [[[.{{.....]]]..}}..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -71.40  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -79.43  [[.[[[.{{{]]]...}}}..{{]]...}}[[[.{{.....]]]..}}..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -78.95  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-15 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-15 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -44.78  [[.{{{{{]].[[.{{{{....]]....}}}}..}}}}}.
@@ -42,12 +42,12 @@
     41  GGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -31.30  [[......{{]]...<<<}}....>>>..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -91.00  [[.[[.{{{{{]]..<<..}}}}}.>>.{{]]..}}..[[..{{]]..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -79.66  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].......}}[[.{{{.]]...}}}..
@@ -56,12 +56,12 @@
 -78.97  [[....{{]].[[.{{{{....]]....}}}}..}}[[.{{{]]....}}}.[[.{{{.]]...}}}..
 -78.83  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]]....}}..[[[.{{{.]]]..}}}..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -75.14  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -64.20  [[[.[[.[[.{{]]..}}{{]]..}}.{{{]]]....}}}
@@ -72,23 +72,23 @@
 -62.80  .[[..[[..{{]]..}}{{{]]..}}}.[[.{{.]]..}}
 -62.00  .[[..[[..{{]]..}}.{{]]..}}..[[..{{]]..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -53.40  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -75.55  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -80.85  [[.[[[.{{{]]]...}}}..{{]]...}}[[[.{{.....]]]..}}..
 -80.74  [[.[[[.{{{]]]...}}}{{.]]....}}[[[.{{.....]]]..}}..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -41.67  [[.{{{{{]].[[.{{{{....]]....}}}}..}}}}}.
@@ -106,7 +106,7 @@
 -43.70  .[[[....{{{]]]....}}}[[[.{{{.]]]..}}}..
 -42.78  .[[[....{{{]]]....}}}.[[.{{{.]]...}}}..
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -92.00  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].......}}[[.{{{.]]...}}}..
@@ -119,7 +119,7 @@
 -91.20  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].....}}.[[[..{{.]]]..}}...
 -91.10  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].....}}[[[[.{{....]]]]..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -22.70  ((((((((((((......))))))))..)))).((((........)))).  best 'nested structure'
@@ -127,7 +127,7 @@
 -58.40  ...[[[.{{{]]]..<<<}}}...>>>[[[.{{.]]]..<<}}..>>...  best 'K-type pseudoknot'
 -68.00  [[[.[[..{{]]..<<<.}}.>>>..{{{.]]]..}}}[[..{{]]..}}  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -34.50  (((((..(((((....))))).((.(((((....)))))..))..)))))  best 'nested structure'
@@ -135,7 +135,7 @@
         no structure available                              best 'K-type pseudoknot'
         no structure available                              best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=C --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=C --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -22.70  ((((((((((((......))))))))..)))).((((........)))).  best 'nested structure'
@@ -143,7 +143,7 @@
         no structure available                              best 'K-type pseudoknot'
         no structure available                              best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  ..(((((....))))).....(((((((((.....))))))))).  best 'nested structure'
@@ -151,7 +151,7 @@
         no structure available                         best 'K-type pseudoknot'
         no structure available                         best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  ..(((((....))))).....(((((((((.....))))))))).  best 'nested structure'
@@ -159,7 +159,7 @@
         no structure available                         best 'K-type pseudoknot'
         no structure available                         best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -34.50  (((((..(((((....))))).((.(((((....)))))..))..)))))  best 'nested structure'
@@ -167,7 +167,7 @@
 -86.88  ..[[[.{{{{{]]]...<<}}}}}.>>.[[.{{.]]..<<.}}..>>...  best 'K-type pseudoknot'
 -86.57  [[.[[.{{{{{]]..<<..}}}}}.>>.{{]]..}}..[[..{{]]..}}  best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=37
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  best 'nested structure'
@@ -175,7 +175,7 @@
         no structure available                                                 best 'K-type pseudoknot'
         no structure available                                                 best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=enforce --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -31.53  ((((((((((((......))))))))...((((........)))).))))  best 'nested structure'
@@ -183,7 +183,7 @@
         no structure available                              best 'K-type pseudoknot'
         no structure available                              best 'H- and K-type pseudoknot'
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17
 >unnamed sequence
 === window: 1 to 45: ===
      3  GGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUG  44
@@ -220,7 +220,7 @@
      4  GGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAU  43
 -55.12  [[[[..{{]]]].[[.{{]]..}}[[.{{.]]..}}..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=37
 >unnamed sequence
 === window: 1 to 69: ===
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGA  66
@@ -1528,7 +1528,7 @@
 -77.60  [[..[[.{{]].[[..[[[.....{{]]]...}}{{]].......}}..}}..{{]]...}}
 -77.10  [[..[[.{{]].[[..[[[.....{{]]]...}}.{{]].....}}...}}..{{]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=D --temperature=25.9
 >unnamed sequence
 === window: 1 to 69: ===
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGA  66
@@ -3580,7 +3580,7 @@
      8  UGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGG  65
 -73.36  [[.....{{]]..<<.[[..[[..{{{.]]....}}}.{{]]..<<.}}.>>}}..>>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
 >unnamed sequence
 === window: 1 to 69: ===
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGA  66
@@ -4151,7 +4151,7 @@
      4  CUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGG  65
 -77.75  [[..[[.{{]][[[..[[[.....{{]]]...}}.{{]]].....}}..}}..{{]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
 >unnamed sequence
 === window: 1 to 69: ===
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGA  66
@@ -4723,7 +4723,7 @@
      4  CUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGG  65
 -77.75  [[..[[.{{]][[[..[[[.....{{]]]...}}.{{]]].....}}..}}..{{]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=37
 >unnamed sequence
 === window: 1 to 50: ===
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGC  48
@@ -4783,7 +4783,7 @@
      4  CCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGG  47
 -61.00  [[.[[.[[[..{{]]]...}}.{{{{{]]..}}}}}{{]]..}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-12 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-12 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=17
 >unnamed sequence
 === window: 1 to 69: ===
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGA  66
@@ -6079,7 +6079,7 @@
 -85.23  [[..[[.{{]][[[..[[[.....{{]]]...}}.{{]]]....}}...}}..{{]]...}}
 -85.13  [[..[[.{{]].[[..[[[.....{{]]]...}}{{]].......}}..}}..{{]]...}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=local --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=17
 >unnamed sequence
 === window: 1 to 50: ===
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGC  48
@@ -6213,18 +6213,18 @@
      2  GGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCU  49
 -69.46  [[[..{{{[[.{{.]]..}}]]].[[[[.{{{..]]]]..}}}..}}}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -61.16  ..[[[[[.{{.]]]]]...<<}}..>>....[[[.{{.]]]..}}  [{]<}>[{]}
 -60.93  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}  [{][{]}}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -90.87  [[[.[[.[[.{{]]..}}{{]]..}}.{{.]]]..}}.[[..{{]]..}}  [[[{]}{]}{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-12 --absoluteDeviation=1 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -50.63  ..[[[[[.{{.]]]]].....}}[[.{{{{]]...}}}}.  [{]}[{]}
@@ -6232,24 +6232,24 @@
     21  UCGUAGCAGUUGACUACUGUUAUGU  45
 -26.01  [[.{{{{{{{.]]..}}}}}}}...  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -70.50  [[[.[[.[[.{{]]..}}{{]]..}}.{{.]]]..}}.[[..{{]]..}}  [[[{]}{]}{]}[{]}
 -70.10  [[.[[[.{{{]]]...}}}{{.]]....}}[[[.{{.....]]]..}}..  [[{]}{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-20 --absoluteDeviation=1 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-9 --Kpenalty=-20 --absoluteDeviation=1 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -76.42  [[..{{{{]].[[.{{{{....]]....}}}}..}}}}[[[[...{{.]]]]...<<<<}}.>>>>...  [{][{]}}[{]<}>
 -76.30  ....[[.{{]].....}}.[[[.....{{]]]...}}.[[[[...{{.]]]]...<<<<}}.>>>>...  [{]}[{]}[{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=B --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -87.14  [[[.[[.[[.{{]]..}}{{]]..}}.{{.]]]..}}.[[..{{]]..}}  [[[{]}{]}{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-9 --Kpenalty=-15 --absoluteDeviation=1 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -53.66  ..[[[[[.{{.]]]]]...<<}}..>>[[.{{.]]..}}.  [{]<}>[{]}
@@ -6257,25 +6257,25 @@
     21  UCGUAGCAGUUGACUACUGUUAUGU  45
 -29.03  .[[..{{{{.]]..<<}}}}..>>.  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --absoluteDeviation=1 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -78.90  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].....}}.[[[.{{{.]]]..}}}..  [{]}[[{]}{]}[{]}
 -78.40  [[....{{]].[[.{{{{....]]....}}}}..}}[[.{{{]]....}}}[[[.{{{.]]]..}}}..  [{][{]}}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --lowProbFilter=0.01 --minHairpinLength=4 --outputLowProbFilter=0.0001 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --lowProbFilter=0.01 --minHairpinLength=4 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --strategy=P --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -90.90  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].....}}.[[[.{{{.]]]..}}}..  0.94  [{]}[[{]}{]}[{]}
 -90.40  [[....{{]].[[.{{{{....]]....}}}}..}}[[.{{{]]....}}}[[[.{{{.]]]..}}}..  0.06  [{][{]}}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-12 --Kpenalty=-20 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --strategy=B --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -78.90  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].....}}.[[[.{{{.]]]..}}}..  0.94  [{]}[[{]}{]}[{]}
 -78.40  [[....{{]].[[.{{{{....]]....}}}}..}}[[.{{{]]....}}}[[[.{{{.]]]..}}}..  0.06  [{][{]}}[{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-15 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -62.70  ..[[.{{]]..}}...[[.{{]]..}}[[.{{.]]..}}.  1.0000000  [{]}[{]}[{]}
@@ -6284,24 +6284,24 @@
 -33.80  .[[.[[.{{]]..}}{{]]....}}  0.9918935  [[{]}{]}
 -30.80  [[.{{{{{{{.]]..}}}}}}}...  0.0081065  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-15 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -90.05  [[[.[[.[[.{{]]..}}{{]]..}}{{{.]]]..}}}[[..{{]]..}}  0.8590384  [[[{]}{]}{]}[{]}
 -89.85  [[.[[[.{{{]]]...}}}..{{]]...}}[[[.{{.....]]]..}}..  0.1409616  [[{]}{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-12 --lowProbFilter=0.01 --minHairpinLength=6 --outputLowProbFilter=0.1 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --Hpenalty=-12 --Kpenalty=-12 --lowProbFilter=0.01 --minHairpinLength=6 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=C --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -69.93  ..[[[[[.{{.]]]]][[.{{]]..}}...}}[[.{{.]]...}}  0.9802762  [{][{]}}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=4 --outputLowProbFilter=0.1 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-15 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=4 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --strategy=A --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -79.43  [[.[[[.{{{]]]...}}}..{{]]...}}[[[.{{.....]]]..}}..  0.6971381  [[{]}{]}[{]}
 -78.87  [[[.[[.[[.{{]]..}}{{]]..}}.{{.]]]..}}.[[..{{]]..}}  0.2295313  [[[{]}{]}{]}[{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --Hpenalty=-12 --Kpenalty=-12 --lowProbFilter=0.01 --maxKnotSize=40 --minHairpinLength=6 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --strategy=D --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -58.98  [[[.[[.[[.{{]]..}}{{]]..}}.{{{]]]....}}}  0.6447001  [[[{]}{]}{]}
@@ -6312,7 +6312,7 @@
     31  CCCAGCUACUCGGGAGGCUC  50
 -27.45  [[[.{{.....]]]..}}..  1.0000000  [{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --lowProbFilter=0.01 --minHairpinLength=2 --outputLowProbFilter=0.0001 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --Hpenalty=-15 --Kpenalty=-20 --lowProbFilter=0.01 --minHairpinLength=2 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --strategy=B --temperature=17 --windowIncrement=20
 >unnamed sequence
       1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -103.66  [[..{{..]]..}}[[[..[[[.....{{]]]...}}.{{]]].......}}[[.{{{.]]...}}}..  0.76  [{]}[[{]}{]}[{]}
@@ -6320,10 +6320,10 @@
 -103.18  [[....{{]].[[.{{{{....]]....}}}}..}}[[.{{{]]....}}}[[[.{{{.]]]..}}}..  0.04  [{][{]}}[{]}[{]}
 -101.56  [[..{{..]]..}}[[[..[[[..[[.{{.]]...}}.{{]]]..<<...}}..>>{{]]]...}}...  0.03  [{]}[[[{]}{]<}>{]}
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-12 --Kpenalty=-12 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=P --temperature=17
 1)  Shape: [{][{]}}[{]}  Score: -229.76  Ratio of MFE: 0.95
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6347,7 +6347,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -78.62  ...[[[.{{.]]]..}}.[[.{{.]]..}}[[[.{{.....]]]..}}..  R: 2  [{]}[{]}[{]}
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-12 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-12 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=B --temperature=37
 1)  Shape: [{]}[{]}[{]}  Score: -202.10  Ratio of MFE: 0.95
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6371,7 +6371,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -65.00  ..[[.{{]][[[..{{]]]...}}.....}}[[.{{{....]]..}}}..  R: 8  [{][{]}}[{]}
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-15 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=4 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 castInput.mfa --Hpenalty=-15 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=4 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=A --temperature=17
 1)  Shape: [{][{]}}[{]}  Score: -256.76  Ratio of MFE: 0.94
 >seq1
       1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6384,7 +6384,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
  -83.41  ..[[[[.{{.]]]][[[..{{]]]....}}....}}..[[..{{]]..}}  R: 6  [{][{]}}[{]}
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-15 --Kpenalty=-20 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --strategy=A --temperature=17
 1)  Shape: [{]}[{]}[{]}  Score: -253.26  Ratio of MFE: 0.94
 >seq1
       1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6397,7 +6397,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
  -85.80  ..[[[[.{{{]]]]..}}}[[..{{{..]]..}}}...[[..{{]]..}}  R: 5  [{]}[{]}[{]}
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-9 --Kpenalty=-15 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-9 --Kpenalty=-15 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9
 1)  Shape: [{]<}>[{]<}>  Score: -205.91  Ratio of MFE: 0.98
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6410,7 +6410,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -72.54  ..[[[.{{{{{]]]...<<}}}}}.>>.[[.{{.]]..<<.}}..>>...  R: 1  [{]<}>[{]<}>
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-12 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=2 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-12 --Kpenalty=-15 --maxKnotSize=40 --minHairpinLength=2 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=D --temperature=25.9
 1)  Shape: [{]}[{]}[{]}  Score: -216.63  Ratio of MFE: 0.94
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -6434,10 +6434,10 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -70.08  ..[[[[.{{.]]]][[[..{{]]]....}}....}}..[[..{{]]..}}  R: 13  [{][{]}}[{]}
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-15 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  castInput.mfa --Hpenalty=-15 --Kpenalty=-12 --maxKnotSize=40 --minHairpinLength=6 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --strategy=C --temperature=25.9
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-12 --Kpenalty=-15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-12 --Kpenalty=-15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -56.70  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
@@ -6505,7 +6505,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -55.30  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
 -55.30  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....' --Hpenalty=-9 --Kpenalty=-20 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....' --Hpenalty=-9 --Kpenalty=-20 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -66.05  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
@@ -6605,7 +6605,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -59.06  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
 -58.99  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-15 --Kpenalty=-20 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-15 --Kpenalty=-20 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -55.76  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
@@ -6673,7 +6673,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -50.83  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 -50.83  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-9 --Kpenalty=-20 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-9 --Kpenalty=-20 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -61.10  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
@@ -6741,7 +6741,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -53.76  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 -53.76  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-9 --Kpenalty=-15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-9 --Kpenalty=-15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -62.47  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
@@ -6809,7 +6809,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -60.82  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
 -60.82  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-12 --Kpenalty=-20 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.' --Hpenalty=-12 --Kpenalty=-20 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -52.90  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
@@ -6877,7 +6877,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -47.20  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 -47.20  ..[[[[[.{{.]]]]].....<<<<<<<<<}}...>>>>>>>>>.  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....' --Hpenalty=-9 --Kpenalty=-15 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....' --Hpenalty=-9 --Kpenalty=-15 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -61.01  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
@@ -6977,7 +6977,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -55.09  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
 -54.97  ....[[[[[[[[.{{{{.]]]]]]]]...<<<<.}}}}...>>>>.....  [{]<}>
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-9 --Kpenalty=-12 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/pKiss  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...' --Hpenalty=-9 --Kpenalty=-12 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -64.29  .[[[[[[[[[[[[..........{{....]]]]]]]]]]]]........<<<<<<<}}.>>>>>>>...  [{]<}>

--- a/Misc/Test-Suite/StefanStyle/Truth/pseudoknots.basic.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/pseudoknots.basic.out
@@ -1,11 +1,11 @@
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_enforce -y 9.99 -z 3 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_enforce -y 9.99 -z 3 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( ( nested structure , -3450 ) , .(((((.((((..(((((.(((...((...))...)))...)))))..))))..))))). )
 ( ( H-type pseudoknot , -3200 ) , ..[[[[.{{{{..(((((.(((...((...))...)))...)))))..]]]]...}}}}. )
 ( ( K-type pseudoknot , -4051 ) , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( ( H- and K-type pseudoknot , -2791 ) , .[[[[[.{{{{..]]]]].[[[...{{........]]]...<<<}}..>>>...}}}}.. )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_enforce_window -w 30 -i 8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_enforce_window -w 30 -i 8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 30) :
 ( ( nested structure , -1080 ) , .(((((.......))))).((....))... )
 ( ( H-type pseudoknot , -1320 ) , .[[[[[...{{..]]]]].......}}... )
@@ -23,7 +23,7 @@ Answer (32, 60) :
 ( ( nested structure , -1090 ) , .........(((((........))))). )
 ( ( H-type pseudoknot , -880 ) , ...[[[...{{]]]...}}......... )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_local -s P -e 0.5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_local -s P -e 0.5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3010 , 3 [[[[.{{{{..(((((.(((...((...))...)))...)))))..]]]]...}}}} 60 )
 ( -3010 , 3 [[[[.{{{{..(((((.(((...((...))...)))...)))))..]]]]....}}}} 61 )
@@ -43,7 +43,7 @@ Answer:
 ( -2990 , 2 [[[[[.{{{{..]]]]].(((...((...))...)))...((((...))))....}}}} 61 )
 ( -2990 , 2 [[[[[.{{{{..]]]]].(((...((...))...)))...((((...))))....}}}} 61 )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_local_window -l 30 -w 40 -i 4 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_local_window -l 30 -w 40 -i 4 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 40) :
 ( -1050 , 2 [[[[[.{{....]]]]].......}} 28 )
 ( -1080 , 2 [[[[[..{{...]]]]].......}} 28 )
@@ -80,21 +80,21 @@ Answer (20, 60) :
 ( -1040 , 31 [[.........{{{{{...]]....}}}}} 61 )
 ( -1040 , 31 [[.........{{{{{....]]...}}}}} 61 )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_mfe -P /vol/gapc/share/gapc/librna/rna_turner1999.par -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -P BGAPDIR/share/gapc/librna/rna_turner1999.par -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3770 , .[[[[[.{{{{..]]]]].(((...(....)....)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_mfe_window -w 70 -i 2 -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe_window -w 70 -i 2 -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 60) :
 ( -3870 , .[[[[[.{{{{..]]]]].(((.(.((...)).).)))...<<<<<..}}}}..>>>>>........... )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_probs -F 0.01 -q 3 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_probs -F 0.01 -q 3 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( ( [{]()<}> , ( -3730 , 4.64817e+23 ) ) , .[[[[[.{{{{..]]]]].(((.............)))...<<<<<..}}}}..>>>>>. )
 ( ( [{](())<}> , ( -3850 , 3.22487e+24 ) ) , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( ( [{]()()<}> , ( -3620 , 2.25487e+23 ) ) , .[[[[[.{{{{..]]]]].((....))...((....))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_probs_window -w 20 -i 10 -q 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_probs_window -w 20 -i 10 -q 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 20) :
 ( ( _()_ , ( -1040 , 102690 ) ) , .(((((.......))))).. )
 ( ( _(_())_ , ( -650 , 195.704 ) ) , ...(((.((....))))).. )
@@ -128,13 +128,13 @@ Answer (40, 60) :
 ( ( _(()_) , ( -560 , 77.0392 ) ) , .(((((........)).))) )
 ( ( _[_{_]_} , ( -50 , 0.616032 ) ) , .[[.{{..]]........}} )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_shapes -q 2 -e 3.8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_shapes -q 2 -e 3.8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( ( [{]()<}> , -3730 ) , .[[[[[.{{{{..]]]]].(((.............)))...<<<<<..}}}}..>>>>>. )
 ( ( [{](_()_)<}> , -3850 ) , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( ( [{]()()<}> , -3620 ) , .[[[[[.{{{{..]]]]].((....))...((....))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_shapes_window -w 30 -i 10 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_shapes_window -w 30 -i 10 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 30) :
 ( ( [{]} , -1320 ) , .[[[[[...{{..]]]]].......}}... )
 Answer (10, 40) :
@@ -146,7 +146,7 @@ Answer (30, 60) :
 ( ( [{]} , -1270 ) , [[.........{{{{{..]]....}}}}}. )
 ( ( ()() , -1170 ) , ((....))...(((((........))))). )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_subopt -c 5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_subopt -c 5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3680 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3680 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
@@ -181,7 +181,7 @@ Answer:
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp_solaris/i386-pc-solaris2.10/pKiss_subopt_window -w 20 -i 2 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_subopt_window -w 20 -i 2 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 20) :
 ( -1040 , .(((((.......))))).. )
 ( -1020 , .(((((.......))))).. )

--- a/Misc/Test-Suite/StefanStyle/Truth/pseudoknots.parametercheck.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/pseudoknots.parametercheck.out
@@ -1,52 +1,52 @@
-#CMD: temp/pKiss_mfe  acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe  acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -u 0 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -u 0 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -u 1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3870 , .[[[[[.{{{{..]]]]].(((.(.((...)).).)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -y +20 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -y +20 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3450 , .(((((.((((..(((((.(((...((...))...)))...)))))..))))..))))). )
 
-#CMD: temp/pKiss_mfe -x -10 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -x -10 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -6460 , ....[[.{{{{..[[.{{.]].........}}...[[[...{{]]]..}}]]...}}}}. )
 
-#CMD: temp/pKiss_mfe -z 5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -z 5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -z 6 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -z 6 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3450 , .(((((.((((..(((((.(((...((...))...)))...)))))..))))..))))). )
 
-#CMD: temp/pKiss_mfe -s p acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -s p acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3450 , .(((((.((((..(((((.(((...((...))...)))...)))))..))))..))))). )
 
-#CMD: temp/pKiss_mfe -l 57 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -l 57 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3520 , ..[[[[.{{{{..]]]]..(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -l 56 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -l 56 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3450 , .(((((.((((..(((((.(((...((...))...)))...)))))..))))..))))). )
 
-#CMD: temp/pKiss_mfe -P /stefan/share/gapc/librna/rna_turner1999.par acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -P BGAPDIR/share/gapc/librna/rna_turner1999.par acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3620 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_mfe -P /stefan/share/gapc/librna/rna_turner2004.par acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_mfe -P BGAPDIR/share/gapc/librna/rna_turner2004.par acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_subopt -c 5.8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_subopt -c 5.8 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3680 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3680 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
@@ -97,7 +97,7 @@ Answer:
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3850 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_subopt -e 3.5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_subopt -e 3.5 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer: 
 ( -3500 , ..[[[[.{{{{..]]]]..(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3500 , ..[[[[.{{{{..]]]]..(((...((...))...)))...<<<<<..}}}}..>>>>>. )
@@ -928,7 +928,7 @@ Answer:
 ( -3750 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 ( -3750 , .[[[[[.{{{{..]]]]].(((...((...))...)))...<<<<<..}}}}..>>>>>. )
 
-#CMD: temp/pKiss_probs_window -q 5 -w 30 -i 10 -F 0 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_probs_window -q 5 -w 30 -i 10 -F 0 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 30) :
 ( ( _ , ( 0 , 0.000127044 ) ) , .............................. )
 ( ( () , ( -1040 , 5176.45 ) ) , .(((((.......)))))............ )
@@ -966,7 +966,7 @@ Answer (30, 60) :
 ( ( [(){]} , ( -820 , 22918.8 ) ) , [[...((....)){{{..]]....}}}... )
 ( ( [{()]} , ( -220 , 0.166007 ) ) , [[.........{{(((...)))..]]..}} )
 
-#CMD: temp/pKiss_probs_window -q 1 -w 35 -i 20 -F 0.1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
+#CMD: x86_64-linux-gnu/x86_64-linux-gnu/pKiss_probs_window -q 1 -w 35 -i 20 -F 0.1 acccccaccccaagggggaCCCAGAGGAAACCACAGGGacacccccaaggggaagggggg
 Answer (0, 35) :
 ( ( _[_{_]_}_ , ( -1320 , 4.4654e+07 ) ) , .[[[[[...{{..]]]]].......}}........ )
 Answer (20, 55) :

--- a/Misc/Test-Suite/StefanStyle/Truth/rnaalishapes.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/rnaalishapes.run.out
@@ -1,12 +1,12 @@
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                     1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-49.44 = -22.83 + -26.61)  0.8856400  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                     1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-61.44 = -28.92 + -32.52)  0.8473120  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.730)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  _
 
@@ -31,38 +31,38 @@
                    141  -aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( 0.00 =  0.00 + 0.00)  .............................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
                                     1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-56.83 = -27.27 + -29.56)  0.8768472  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-27.52 = -16.50 + -11.02)  ..............((((.....))))...........((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.360)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-20.49 = -7.49 + -13.00)  ......................................((((((.......((((........(((.....)))..................))))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-13.78 = -13.95 + 0.17)  .......(((.((((.....)))).)))............  (sci:  0.600)  []
 
                       21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (  0.00 =   0.00 + 0.00)  ................................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-59.30 = -29.58 + -29.72)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-22.83 = -10.16 + -12.67)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.400)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.07 = -9.21 + 0.14)  .......(((.((((.....)))).)))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                       1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-9.71 = -9.85 +  0.14)  .......(((.((((.....)))).)))............  []
 
@@ -72,7 +72,7 @@
                      21  rGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 ( 0.00 =  0.00 +  0.00)  ................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-17.53 =  -5.19 + -12.34)  ...............((((...................))))((.((....(((((......((((.....))))................)))))))))  (sci:  0.440)  [][]
 
@@ -88,15 +88,15 @@
                         81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -3.86 =  -0.36 +  -3.50)  ..............((((((.((............................................)).))).)))............  (sci:  0.130)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-3.12 = -3.27 + 0.15)  0.3941977  ...........................................(((....)))....................................................................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                  1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-7.46 = -7.33 + -0.13)  0.3566348  ......................................((((((.......((((.....................................))))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-16.36 = -16.00 + -0.36)  0.6882692  .......((((((((.....))))))))............  []
 
@@ -106,19 +106,19 @@
                                   21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( -2.49 =  -1.13 + -1.36)  0.4967891  ((((..................))))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-26.80 = -21.51 + -5.29)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.070)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-19.45 = -7.24 + -12.21)  ......................................((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-33.70 = -23.71 + -9.99)  0.6883790  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.140)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -2.26 =  -1.08 + -1.18)  0.8222531  .........(((.............)))............  []
 
@@ -134,7 +134,7 @@
                                   41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -9.34 =  -6.51 + -2.83)  0.9714581  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-22.30 = -10.44 + -11.86)  ...............((((.(((.......))).....))))((.((....(((((..(..(((((.....))))............))..)))))))))  (sci:  0.480)  [][]
 
@@ -159,15 +159,15 @@
                         71  rGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( -3.52 =   0.72 +  -4.24)  ........................(((((((.((.........................................)).)).)).)))............  (sci:  0.090)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-30.33 = -20.19 + -10.14)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.260)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-11.39 = -11.39 + 0.00)  ......................................((((((.......((((.....................................))))))))))...................................................................  (sci:  0.150)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  _
 
@@ -210,7 +210,7 @@
                    131  yggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( 0.00 =  0.00 + 0.00)  .......................................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-18.41 =  -7.04 + -11.37)  0.0397469  ........................................((((.(....)(((((.......(((.....)))................).))))))))  (sci:  0.420)  [[][]]
 
@@ -235,15 +235,15 @@
                                    71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -2.82 =   0.28 +  -3.10)  0.2272295  ........................(((.((...................................................)).)))............  (sci:  0.080)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-28.46 = -19.26 + -9.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.210)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-39.63 = -28.64 + -10.99)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.08 = -1.90 + -1.18)  .........(((.............)))............  []
 
@@ -253,19 +253,19 @@
                       61  AAUCCCAUCGAACGCG  76
 (  0.00 =  0.00 +  0.00)  ................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                       1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-8.45 = -8.36 + -0.09)  .......((..((((.....))))..))........................  (sci:  0.400)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-1.82 = -1.88 + 0.06)  0.1150177  ..........................................((.....))......................................................................................................................  (sci:  0.030)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-12.40 = -10.24 + -2.16)  .......(((((((.......)))))))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.11 = -2.99 + -0.12)  .........((((...........))))............  (sci:  0.450)  []
 
@@ -281,19 +281,19 @@
                       41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -7.89 = -5.65 + -2.24)  ...........(((((.......)))))........  (sci:  0.980)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                    1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-19.71 = -19.47 + -0.24)  0.2291417  .((((((((((((((.....)))))))))..........)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-46.87 = -17.23 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  2.140)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                  1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-7.76 = -7.66 + -0.10)  0.5906838  .......((..((((.....))))..))........................  (sci:  0.320)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-25.31 = -14.94 + -10.37)  0.5861077  .......((((((((.....))))))))............  (sci:  1.300)  []
 (-24.86 = -13.40 + -11.46)  0.2741686  ...(((.((((((((.....)))))))).......)))..  (sci:  1.270)  []
@@ -302,7 +302,7 @@
 ( -3.57 =  -0.65 +  -2.92)  0.6002689  ((((..................))))......  (sci:  0.640)  []
 ( -3.04 =  -1.22 +  -1.82)  0.2492340  (((((..............)))))........  (sci:  0.540)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-19.78 =  -5.01 + -14.77)  ...............((((.(((.......))).....))))((.((....((((((.....((((.....))))..............)).))))))))  (sci:  0.500)  [][]
 (-19.62 =  -5.19 + -14.43)  ...............((((.(((.......))).....))))((.((....(((((......((((.....))))................)))))))))  (sci:  0.500)  [][]
@@ -351,7 +351,7 @@
 ( -2.42 =   1.14 +  -3.56)  .........................(((.((.((.........................................)).)).)))...............  (sci:  0.080)  []
 ( -1.86 =   3.13 +  -4.99)  ........................(((((((...............................................)).)).)))............  (sci:  0.060)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                          1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-25.43 = -13.89 + -11.54)  .((((((((((((((.....)))))))))..........)))))........  (sci:  1.460)  []
 (-25.09 = -13.80 + -11.29)  ...((((((((((((.....)))))))))......)))..............  (sci:  1.440)  []
@@ -361,11 +361,11 @@
 (-24.46 = -11.70 + -12.76)  .((((..((((((((.....))))))))..............))))......  (sci:  1.400)  []
 (-24.45 = -14.28 + -10.17)  ......(((((((((.....))))))))).......................  (sci:  1.400)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                      1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-9.66 = -9.85 + 0.19)  .......(((.((((.....)))).)))........................  (sci:  0.550)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 ( -8.67 = -3.12 +  -5.55)  0.8196195  .........((((...........))))............  []
 
@@ -383,7 +383,7 @@
                                   41  MSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-13.73 = -5.65 +  -8.08)  0.9915288  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-14.64 =  -3.87 + -10.77)  ...............((((...................))))((.((....(((((......((((.....))))................)))))))))  (sci:  0.440)  [][]
 (-14.19 =  -5.48 +  -8.71)  ........................................((((.......(((((......((((.....))))................)))))))))  (sci:  0.420)  []
@@ -418,16 +418,16 @@
 ( -0.74 =   1.92 +  -2.66)  ...............(((.((...............................................)).)))...............  (sci:  0.030)  []
 ( -0.62 =   2.57 +  -3.19)  ..............(((((....................................................)).)))............  (sci:  0.030)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-41.94 = -32.74 + -9.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-22.27 = -10.16 + -12.11)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  []
 (-22.14 =  -9.72 + -12.42)  ......................................((((((.......((((((.....((((.....))))..............)).))))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -1.91 = -0.84 + -1.07)  .........(((.............)))............  []
 
@@ -443,7 +443,7 @@
                       41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -8.22 = -5.65 + -2.57)  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                     1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-19.11 =  -5.51 + -13.60)  0.1364605  ...............((((...................))))((.((....((((((......(((.....)))...............)).))))))))  (sci:  0.420)  [][]
 (-18.65 =  -5.80 + -12.85)  0.0611172  ...............((((...................))))((.((....((((((....(((.......)))...............)).))))))))  (sci:  0.410)  [][]
@@ -483,14 +483,14 @@
 ( -4.97 =  -1.43 +  -3.54)  0.2926768  ........................(((.((...................................................)).)))............  (sci:  0.140)  []
 ( -4.26 =   0.55 +  -4.81)  0.0857496  ........................(((((((...............................................)).)).)))............  (sci:  0.120)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-7.59 = -7.52 + -0.07)  .......................................(((((.......((((.....................................)))))))))....................................................................  []
 (-6.82 = -6.89 +  0.07)  .......................................(((((.......(((.......................................))))))))....................................................................  []
 (-6.65 = -6.66 +  0.01)  .......................................(((((....................................................)))))....................................................................  []
 (-6.65 = -6.84 +  0.19)  .......................................((((((((.............................................))).)))))....................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-18.46 = -16.56 + -1.90)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.250)  []
 (-18.25 = -16.50 + -1.75)  ..............((((.....))))...........((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.240)  [][]
@@ -498,7 +498,7 @@
 (-17.59 = -15.64 + -1.95)  ...............................(((....((((((.......(((((......((((.....))))................))))))))))).)))...............................................................  (sci:  0.240)  []
 (-17.53 = -15.32 + -2.21)  ......................................((((((.......((((((.....((((.....))))..............)).))))))))))...................................................................  (sci:  0.240)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 (-3.89 = -3.26 + -0.63)  .........(((.............)))............  []
 
@@ -508,21 +508,21 @@
                      41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-7.48 = -7.32 + -0.16)  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-22.07 = -20.29 + -1.78)  0.6465180  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.880)  [[][][]]
 (-21.15 = -19.51 + -1.64)  0.0740660  ((((((...(((.............))).(((((.......))))).....(((((.......))))).)))))).  (sci:  0.840)  [[][][]]
 (-21.08 = -19.30 + -1.78)  0.1278285  (((((((..(((.............)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.840)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-8.77 = -8.90 + 0.13)  .......(((.((((.....)))).)))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                                     1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-47.04 = -17.40 + -29.64)  0.6661093  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                               1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 (0.00 = 0.00 + 0.00)  0.9971766  ........................................  _
 
@@ -542,11 +542,11 @@
                             151  RRGARACWc-MYRCrmaaa  169
 (0.00 = 0.00 + 0.00)  1.0000000  ...................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-29.48 = -20.32 + -9.16)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.120)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                                  1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-0.74 = -0.85 +  0.11)  0.1565003  ..........................................((.....))......................................................................................................................  (sci:  0.010)  []
 (-0.53 = -0.73 +  0.20)  0.1131314  ..........................................((.....))((((.....................................)))).........................................................................  (sci:  0.010)  [][]
@@ -557,11 +557,11 @@
 ( 0.20 =  0.12 +  0.08)  0.0341900  ...................................................((((.....................................)))).........................................................................  (sci: 0.000)  []
 ( 0.24 =  0.47 + -0.23)  0.0320090  .......................................((.(((...)))((((.....................................))))...))....................................................................  (sci: 0.000)  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-56.26 = -29.58 + -26.68)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.660)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                                  1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 ( 0.00 =  0.00 +  0.00)  0.3307472  ........................................  _
 
@@ -597,7 +597,7 @@
                                141  -aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( 0.00 =  0.00 +  0.00)  0.8342918  .............................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
                       1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-5.19 = -5.58 +  0.39)  .........................................(((.(....)((((.....................................)))).)))  (sci:  0.100)  [[][]]
 (-4.83 = -5.20 +  0.37)  .........................................(((.(....)(((((..................................).)))).)))  (sci:  0.090)  [[][]]
@@ -646,18 +646,18 @@
                      81  -----u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( 0.00 =  0.00 +  0.00)  .........................................................................................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
                                     1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-43.89 = -32.74 + -11.15)  0.1160172  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-0.75 = -0.85 + 0.10)  0.0900757  ..........................................((.....))......................................................................................................................  (sci:  0.010)  []
 (-0.43 = -0.53 + 0.10)  0.0537029  ..........................................(((...)))......................................................................................................................  (sci:  0.010)  []
 ( 0.00 =  0.00 + 0.00)  0.0267299  .........................................................................................................................................................................  (sci: 0.000)  _
 ( 0.17 =  0.12 + 0.05)  0.0204102  ...................................................((((.....................................)))).........................................................................  (sci: 0.000)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -1.91 = -0.84 + -1.07)  .........(((.............)))............  (sci:  0.280)  []
 
@@ -673,25 +673,25 @@
                       41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -8.22 = -5.65 + -2.57)  ...........(((((.......)))))........  (sci:  1.010)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                   1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-11.93 = -12.12 + 0.19)  0.3768381  .......(((.((((.....)))).)))........................  (sci:  0.560)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-18.31 = -17.92 + -0.39)  .......((((((((.....))))))))........................  []
 (-18.11 = -15.95 + -2.16)  .......(((((((.......)))))))........................  []
 (-17.66 = -15.18 + -2.48)  .......((((((((.....)))))))).........(......).......  [][]
 (-17.46 = -13.21 + -4.25)  .......(((((((.......))))))).........(......).......  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-11.49 = -11.39 + -0.10)  ......................................((((((.......((((.....................................))))))))))...................................................................  []
 (-11.36 = -11.27 + -0.09)  ......................................((((((.......(((((..................................).))))))))))...................................................................  []
 (-10.95 = -11.04 +  0.09)  ......................................((((((.......((((.........((.....))...................))))))))))...................................................................  []
 (-10.66 = -10.73 +  0.07)  ......................................((((((.......(((.......................................)))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-15.97 = -14.01 + -1.96)  0.0143560  .......(((((((.......)))))))............  []
 (-15.71 = -15.33 + -0.38)  0.2740186  .......((((((((.....))))))))............  []
@@ -715,7 +715,7 @@
 ( -2.18 =  -0.83 + -1.35)  0.1408771  (((((.(..........).)))))........  []
 ( -1.94 =  -0.59 + -1.35)  0.1122729  .((((.(..........).)))).........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( -6.40 =  -6.30 + -0.10)  0.1957547  ........................................((((.......((((.....................................))))))))  []
 ( -6.13 =  -6.15 +  0.02)  0.1070419  ........................................((((.......(((((........((.....)).................).))))))))  []
@@ -765,22 +765,22 @@
 (  0.41 =   0.23 +  0.18)  0.1278445  .........................(((.....................................................)))...............  []
 (  0.58 =   0.67 + -0.09)  0.0961977  .........................(((..(...............................................)..)))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-31.59 = -18.90 + -12.69)  .((((((((((((((.....)))))))))..........)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
                                  1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-7.69 = -7.66 + -0.03)  0.6008547  .......((..((((.....))))..))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                                 1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-8.62 = -8.90 + 0.28)  0.8959865  .......(((.((((.....)))).)))............  []
 
                                21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( 0.00 =  0.00 + 0.00)  0.9738398  ................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( -4.06 =  -4.35 + 0.29)  ........................................((((.......((((.....................................))))))))  (sci:  0.090)  []
 
@@ -793,17 +793,17 @@
                       91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (  0.00 =   0.00 + 0.00)  ...............................................................................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                     1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-30.58 = -15.47 + -15.11)  0.0800952  .............(((...((....))...........((((((((....))(((((.....((((.....))))..............)).))).))))))...........................................))).....................  [[][[][]]]
 (-30.32 = -16.85 + -13.47)  0.0502938  .............(((...((....))...........((((((.......((((((.....((((.....))))..............)).))))))))))...........................................))).....................  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-29.96 = -16.50 + -13.46)  ..............((((.....))))...........((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.390)  [][]
 (-29.88 = -16.56 + -13.32)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.390)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                     1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -9.68 =  -4.72 +  -4.96)  0.8268605  .........((((...........))))............  (sci:  1.000)  []
 
@@ -813,7 +813,7 @@
                                    61  AAUCCCAUCGAACGCG  76
 (  0.00 =   0.00 +   0.00)  0.9998100  ................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-0.71 = -0.85 +  0.14)  ..........................................((.....)).................................................  []
 (-0.49 = -0.73 +  0.24)  ..........................................((.....))((((.....................................))))....  [][]
@@ -836,15 +836,15 @@
                      81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  .........................................................................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
                                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-21.98 = -10.16 + -11.82)  0.0280410  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
                                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.36 = -11.10 + -10.26)  0.1582262  .......((((((((.....))))))))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 ( -5.19 =  -4.39 + -0.80)  0.4517321  .........((((...........))))............  (sci:  0.570)  []
 
@@ -854,19 +854,19 @@
                                   61  ARUCCYRKCGVDSSMR  76
 (  0.00 =   0.00 +  0.00)  1.0000000  ................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-23.71 = -13.45 + -10.26)  0.1620205  .......((((((((.....))))))))........................  (sci:  1.100)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-13.96 = -13.61 + -0.35)  0.2324163  .......((((((((.....))))))))........................  (sci:  0.800)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-15.97 = -14.01 + -1.96)  .......(((((((.......)))))))........................  (sci:  0.640)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.26 = -3.12 + -0.14)  .........((((...........))))............  (sci:  0.500)  []
 
@@ -876,19 +876,19 @@
                       61  AAUCCCAUCGAACGCG  76
 (  0.00 =  0.00 +  0.00)  ................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-21.28 = -19.50 + -1.78)  0.7687765  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.43 = -9.90 + -11.53)  .......((((((((.....))))))))........................  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-8.67 = -8.90 + 0.23)  .......(((.((((.....)))).)))........................  (sci:  0.520)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                  1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-5.95 = -5.91 + -0.04)  0.6704657  .......((..((((.....))))..))............  []
 
@@ -898,7 +898,7 @@
                                 21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( 0.00 =  0.00 +  0.00)  0.9593508  ................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                  1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-2.94 = -3.37 +  0.43)  0.2177205  .........................................(((.(.....((((.....................................))))))))  []
 (-2.18 = -2.48 +  0.30)  0.0570744  .........................................((......))((((.....................................))))....  [][]
@@ -913,15 +913,15 @@
                                 91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  0.9969431  ...............................................................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-40.67 = -30.49 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-33.38 = -22.39 + -10.99)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.290)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
                        1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 (-11.00 = -6.01 + -4.99)  .........((((...........))))............  []
 
@@ -932,21 +932,21 @@
                       41  MSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-15.95 = -8.67 + -7.28)  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-44.36 = -35.37 + -8.99)  0.7326262  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.100)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
                                     1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-21.36 = -11.10 + -10.26)  0.0554345  .......((((((((.....))))))))........................  (sci:  1.230)  []
 (-20.85 =  -6.51 + -14.34)  0.0244474  ....((.((((((((.....)))))))).........(....).))......  (sci:  1.200)  [[][]]
 (-20.40 =  -8.23 + -12.17)  0.0115462  .......((((((((.....)))))))).........(......).......  (sci:  1.180)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-48.26 = -21.51 + -26.75)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.920)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                     1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -9.98 =  -4.39 +  -5.59)  0.3111074  .........((((...........))))............  []
 
@@ -962,7 +962,7 @@
                                    41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-15.33 =  -7.25 +  -8.08)  0.3775144  ...........(((((.......)))))........  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
                                  1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-1.92 = -2.06 +  0.14)  0.1406524  ..........................................(((...))).................................................  []
 (-1.33 = -1.51 +  0.18)  0.0498855  ..........................................(((...))).(((.....................................))).....  [][]
@@ -981,15 +981,15 @@
                                 81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  0.9812828  .........................................................................................  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-31.70 = -29.92 + -1.78)  0.8044733  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-34.22 = -27.71 + -6.51)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 
@@ -1017,11 +1017,11 @@
                     141  _____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  .............................  (sci: 0.000)  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-28.62 = -27.71 + -0.91)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                               1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-18.23 = -7.24 + -10.99)  0.48  ......................................((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  (sci:  0.350)  0.96  []
 (-15.52 = -4.45 + -11.07)  0.01  ..............(((.......)))...........((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  (sci:  0.300)  0.03  [][]
@@ -1029,11 +1029,11 @@
 (-12.85 = -0.30 + -12.55)  0.00  ..............(((.......)))...........((((((((....))(((((......(((.....)))...............)).))).))))))...................................................................  (sci:  0.250)  0.00  [][[][]]
 ( -1.97 =  6.58 +  -8.55)  0.00  ...........(((.((((...................)))).(((....)))..........)))............................(((.((...................................................)).)))............  (sci:  0.040)  0.00  [[][]][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-29.36 = -16.90 + -12.46)  0.4454466  .(((((.((((((((.....))))))))...........)))))........  (sci:  1.270)  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
                       1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-7.76 = -7.66 + -0.10)  .......((..((((.....))))..))............  1.00  []
 
@@ -1044,7 +1044,7 @@
 ( 0.00 =  0.00 +  0.00)  ................................  0.94  _
 ( 2.09 =  2.75 + -0.66)  ((..((...............))..)).....  0.06  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-14.77 = -1.69 + -13.08)  0.2260705  ...............((((...................))))((.((....((((........(((.....)))..................))))))))  0.6212863  [][]
 (-14.59 = -3.91 + -10.68)  0.1676597  ........................................((((.......((((........(((.....)))..................))))))))  0.3642045  []
@@ -1064,16 +1064,16 @@
                                   91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -2.65 =  0.76 +  -3.41)  0.5976160  ....(((.((...................................................)).)))............  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-32.37 = -21.17 + -11.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.260)  0.9876815  [[][][]]
 (-29.69 = -19.67 + -10.02)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  0.0123185  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                 1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-9.71 = -9.85 + 0.14)  0.8847973  .......(((.((((.....)))).)))........................  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                              1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 ( -9.71 = -4.72 + -4.99)  0.83  .........((((...........))))............  1.00  []
 
@@ -1083,19 +1083,19 @@
                             41  MSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-14.60 = -7.32 + -7.28)  1.00  ...........(((((.......)))))........  1.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-52.06 = -22.34 + -29.72)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  2.170)  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-64.02 = -34.38 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-61.06 = -34.38 + -26.68)  0.15  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                          1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-26.22 = -13.80 + -12.42)  ...((((((((((((.....)))))))))......)))..  (sci:  1.580)  1.00  []
 
@@ -1103,7 +1103,7 @@
 (  0.00 =   0.00 +   0.00)  ......................  (sci: 0.000)  0.89  _
 (  1.78 =   3.10 +  -1.32)  ......((....))........  (sci: -6.190)  0.11  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                     1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-15.46 =  -2.38 + -13.08)  0.0381260  ...............((((...................))))((.((....((((........(((.....)))..................))))))))  0.4314770  [][]
 (-16.07 =  -5.39 + -10.68)  0.1056143  ........................................((((.......((((........(((.....)))..................))))))))  0.2648020  []
@@ -1130,15 +1130,15 @@
                                    81  -----u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( -3.13 =   0.28 +  -3.41)  0.1736810  ..............(((.((...................................................)).)))............  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-18.28 = -17.92 + -0.36)  .......((((((((.....))))))))........................  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                               1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-26.99 = -25.21 + -1.78)  0.83  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.910)  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                               1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-16.40 = -16.00 + -0.40)  0.66  .......((((((((.....))))))))............  1.00  []
 
@@ -1146,41 +1146,41 @@
 (  0.00 =   0.00 +  0.00)  1.00  ......................  1.00  _
 (  5.47 =   5.61 + -0.14)  0.00  ......((............))  0.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-14.49 = -12.33 + -2.16)  .......(((((((.......)))))))........................  1.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
                                     1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-27.33 = -16.90 + -10.43)  0.4556682  .(((((.((((((((.....))))))))...........)))))........  (sci:  1.180)  0.9842550  []
 (-24.90 = -13.23 + -11.67)  0.0067193  .(((((.((((((((.....))))))))...........)))))(......)  (sci:  1.080)  0.0157450  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-49.92 = -17.40 + -32.52)  0.63  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                  1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 (-9.79 = -9.92 +  0.13)  0.6122040  .......(((.((((.....)))).)))............  (sci:  0.490)  0.9997273  []
 
                                 31  awcwuhURWWYDYSCYUUUUuG  52
 ( 0.00 =  0.00 +  0.00)  0.9910235  ......................  (sci: 0.000)  0.9910276  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-29.52 = -20.32 + -9.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.9832670  [[][][]]
 (-27.19 = -18.95 + -8.24)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.0167330  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.71 = -9.85 +  0.14)  .......(((.((((.....)))).)))........................  (sci:  0.560)  0.99  []
 (-6.43 = -6.33 + -0.10)  .......(((.((((.....)))).))).........(......).......  (sci:  0.370)  0.01  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-38.31 = -28.13 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.130)  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.93  _
 ( 2.13 =  2.04 +  0.09)  ................................(......)  (sci: -0.110)  0.07  []
@@ -1209,7 +1209,7 @@
                     151  AGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  ...................  (sci: 0.000)  1.00  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-21.79 =  -7.13 + -14.66)  ..............((.((.(((.......)))).)..))((((.......(((((..(..(((((.....))))............))..)))))))))  0.8412972  [][]
 
@@ -1222,11 +1222,11 @@
                         91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -3.74 =   1.17 +  -4.91)  ....(((((((.((.........................................)).)).)).)))............  0.9999965  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-58.28 = -28.64 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.770)  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
                                  1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-0.70 = -0.85 +  0.15)  0.1033758  ..........................................((.....))......................................................................................................................  (sci:  0.010)  0.5084971  []
 ( 1.48 =  1.77 + -0.29)  0.0030591  .......................................((.((.....)).(((.....................................)))....))....................................................................  (sci: -0.030)  0.3405641  [[][]]
@@ -1236,7 +1236,7 @@
 ( 5.66 =  5.95 + -0.29)  0.0000034  .......................(.........).....((.((.....)).(((.....................................)))....))....................................................................  (sci: -0.100)  0.0024012  [][[][]]
 ( 8.01 =  8.42 + -0.41)  0.0000001  ................(......(.........).....((.((.....)).(((.....................................)))....))..................................................).................  (sci: -0.140)  0.0001718  [[][[][]]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
                             1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGC  40
 ( 1.39 =  1.18 +  0.21)  0.04  ..............((((.....)))).............  0.64  []
 ( 0.00 =  0.00 +  0.00)  0.35  ........................................  0.35  _
@@ -1275,7 +1275,7 @@
 ( 0.00 =  0.00 +  0.00)  0.72  .............................  0.72  _
 ( 1.44 =  1.94 + -0.50)  0.07  ...........(....)............  0.28  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
                          1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-14.26 =  -1.87 + -12.39)  ...............((((...................))))((.((....(((((..(..(((((.....))))............))..)))))))))  (sci:  0.430)  0.74  [][]
 (-15.11 =  -5.11 + -10.00)  ........................................((((.......(((((..(..(((((.....))))............))..)))))))))  (sci:  0.460)  0.15  []
@@ -1303,16 +1303,16 @@
 ( -2.01 =   1.33 +  -3.34)  ..............(((.((...................................................)).)))............  (sci:  0.080)  1.00  []
 (  2.03 =   6.05 +  -4.02)  .......(.....)(((.((...................................................)).)))............  (sci: -0.080)  0.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-34.13 = -27.71 + -6.42)  0.7340125  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  1.0000000  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-22.47 = -20.29 + -2.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.890)  0.9843313  [[][][]]
 (-20.40 = -18.99 + -1.41)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  (sci:  0.810)  0.0156687  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                               1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.96 =  -3.26 + -0.70)  0.88  .........(((.............)))............  1.00  []
 
@@ -1330,7 +1330,7 @@
                              41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -7.50 =  -7.32 + -0.18)  0.96  ...........(((((.......)))))........  1.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                    1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-11.29 =  -7.60 + -3.69)  0.0205377  ..............(((..((....)).....)).)....((((.......(((((..(..(((((.....))))............))..)))))))))  0.5413329  [][]
 (-10.88 =  -5.74 + -5.14)  0.0101860  ..............(((..((....)).....)).)....((((.(....).((((..(..(((((.....))))............))..)))).))))  0.3389060  [][[][]]
@@ -1349,7 +1349,7 @@
                                   81  -----u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( -1.20 =   0.03 + -1.23)  0.0818976  ...............(((.((.((.........................................)).)).)))...............  0.9957507  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=20
                          1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-55.59 = -25.19 + -30.39)  (((((((..((((.((...))...)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -1367,13 +1367,13 @@ Sampling results:
 
 (-56.83 = -27.27 + -29.56)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                    1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (0.27 = 0.13 + 0.14)  ..........................................(((...)))......................................................................................................................  (sci: 0.000)  0.48  []
 (0.00 = 0.00 + 0.00)  .........................................................................................................................................................................  (sci: 0.000)  0.34  _
 (0.85 = 0.58 + 0.27)  ..........................................(((...)))((((.....................................)))).........................................................................  (sci: -0.010)  0.18  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.80  _
 ( 1.86 =  2.00 + -0.14)  ..............((((.....)))).............  (sci: -0.170)  0.20  []
@@ -1430,7 +1430,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  .......................................  (sci: 0.000)  0.99  _
 ( 5.19 =  4.95 +  0.24)  .......((........))....................  (sci: -1.460)  0.01  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=25.9 --windowIncrement=30
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-31.52 = -20.32 + -11.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -1449,7 +1449,7 @@ Sampling results:
 (-31.52 = -20.32 + -11.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.9000000  [[][][]]
 (-28.97 = -18.95 + -10.02)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.1000000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=30
                                    1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-37.33 = -28.13 + -9.20)  0.8051418  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.108)  [[][][]]
@@ -1558,11 +1558,11 @@ Sampling results:
 (-37.33 = -28.13 + -9.20)  0.8051418  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.110)  0.9900000  [[][][]]
 (-33.49 = -25.25 + -8.24)  0.0012471  (((((((......................(((((.......))))).....(((((.......)))))))))))).  (sci:  0.990)  0.0100000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                          1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-29.68 = -16.99 + -12.69)  .((((((((((((((.....)))))))))..........)))))........  (sci:  1.400)  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=10
                             1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  0.75  ........................................  (sci: -0.000)  _
@@ -3075,7 +3075,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.99  .......................................  (sci: 0.000)  0.99  _
 ( 3.53 =  4.19 + -0.66)  0.00  ...............((...............)).....  (sci: -0.750)  0.01  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
                       1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCY  100
 (-2.32 = -2.52 +  0.20)  ........................................((((.......((((.....................................))))))))  0.9000000  []
 ( 0.66 =  0.51 +  0.15)  .........................................((......)).(((.....................................))).....  0.1000000  [][]
@@ -3104,19 +3104,19 @@ Sampling results:
                      71  rGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 ( 0.00 =  0.00 +  0.00)  ...................................................................................................  1.0000000  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
                         1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-12.49 = -12.49 +  0.00)  ......................................((((((.......((((.....................................))))))))))...................................................................  0.7800000  []
 (-10.17 = -10.41 +  0.24)  ......................................((((((..((...))...........((.....)).......................))))))...................................................................  0.1100000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=10
                                1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-24.90 = -12.20 + -12.70)  0.01  ....................((.........)).....((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  0.49  [][]
 (-25.84 = -13.91 + -11.93)  0.08  ......................................((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  0.38  []
 (-23.61 = -10.01 + -13.60)  0.00  .............(((....((.........)).....((((((.......((((((......(((.....)))...............)).))))))))))...........................................))).....................  0.08  [[][]]
 (-22.37 = -10.47 + -11.90)  0.00  ..............(((.......)))...........((((((.......((((((....(((.......)))...............)).))))))))))...........................................((...............)).....  0.05  [][][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=20
                              1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.00 =  0.00 +  0.00)  0.25  ........................................  (sci: -0.000)  _
@@ -3257,7 +3257,7 @@ Sampling results:
 
 (  0.00 =  0.00 +  0.00)  0.89  .............................  (sci: 0.000)  1.00  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-56.26 = -23.78 + -32.48)  0.00  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -3365,7 +3365,7 @@ Sampling results:
 
 (-61.25 = -28.64 + -32.61)  0.12  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-36.98 = -30.64 + -6.34)  (((((((..((((.((...))...)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -3473,11 +3473,11 @@ Sampling results:
 
 (-38.62 = -32.71 + -5.91)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-35.10 = -28.64 + -6.46)  0.7921208  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.070)  1.0000000  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
@@ -3524,20 +3524,20 @@ Sampling results:
                    131  _____CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 + 0.00)  .......................................  (sci: 0.000)  1.0000000  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-11.26 = -11.32 + 0.06)  .......(((.((((.....)))).)))........................  (sci:  0.520)  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-34.66 = -24.48 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  1.0000000  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=20
                                1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-33.50 = -22.26 + -11.24)  0.71  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.90  [[][][]]
 (-31.63 = -21.56 + -10.07)  0.03  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.10  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSR  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( -7.25 = -1.70 +  -5.55)  .........((((...........))))............  []
@@ -3860,12 +3860,12 @@ Sampling results:
 (  0.00 =  0.00 +   0.00)  ................  0.99  _
 (  5.16 =  4.99 +   0.17)  ........(......)  0.01  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
                                1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-33.50 = -22.26 + -11.24)  0.71  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.90  [[][][]]
 (-31.63 = -21.56 + -10.07)  0.03  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.10  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
                             1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-7.03 = -6.61 + -0.42)  0.01  .......((..((((.....))))..)).........(....).........  [][]
@@ -3975,12 +3975,12 @@ Sampling results:
 (-7.84 = -7.02 + -0.82)  0.04  ....((.((..((((.....))))..)).........(....).))......  0.11  [[][]]
 (-7.59 = -7.25 + -0.34)  0.03  .......((..((((.....))))..)).........(......).......  0.11  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-2.83 = -2.65 + -0.18)  .......................................((.((.....))((((.....................................))))...))....................................................................  (sci:  0.040)  0.60  [[][]]
 (-2.66 = -2.93 +  0.27)  ..........................................((.....))((((.....................................)))).........................................................................  (sci:  0.040)  0.40  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 (-11.62 = -5.52 +  -6.10)  0.6555246  .........((((...........))))............  0.9900000  []
 ( -5.44 =  0.57 +  -6.01)  0.0000143  .....((..((((...........))))..))..(....)  0.0100000  [][]
@@ -3994,7 +3994,7 @@ Sampling results:
 (-17.45 = -8.56 +  -8.89)  0.9730040  ...........(((((.......)))))........  0.9900000  []
 (-14.15 = -4.54 +  -9.61)  0.0031476  ....(.....)(((((.......)))))........  0.0100000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
                                1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-29.16 = -13.14 + -16.02)  0.50  ....((.((((((((.....)))))))).........(....).))......  (sci:  1.132)  [[][]]
@@ -4104,13 +4104,13 @@ Sampling results:
 (-27.15 = -14.38 + -12.77)  0.02  ...(((.((((((((.....)))))))).......)))..............  (sci:  1.050)  0.11  []
 (-27.00 = -13.37 + -13.63)  0.01  .......((((((((.....)))))))).........(......).......  (sci:  1.050)  0.03  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
                       1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (-3.21 = -2.86 + -0.35)  .......................................((.((.......((((.....................................)))))).))....................................................................  (sci:  0.040)  0.70  []
 ( 2.01 =  1.81 +  0.20)  ................................(......)..((.....)).(((.....................................)))..........................................................................  (sci: -0.030)  0.20  [][][]
 ( 0.05 =  0.47 + -0.42)  .......................................((.(((...))).(((.....................................)))....))....................................................................  (sci: 0.000)  0.10  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
                          1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-30.24 = -14.58 + -15.66)  .............(((.((.((.........))).)..((((((.(....)(((((.....(((((.....))))............)...)))))))))))...........................................))).....................  (sci:  0.370)  0.18  [[][[][]]]
 (-27.97 = -13.04 + -14.93)  ..............(((.......))).....((.(..((((((.(....)(((((..(..(((((.....))))............))..)))))))))))..(..................................).....))).....................  (sci:  0.340)  0.13  [][[[][]][]]
@@ -4126,7 +4126,7 @@ Sampling results:
 (-25.77 = -10.38 + -15.39)  ................................((.(..((((((.(....)((((((.(...((((.....))))............).)).))))))))))..............(..............).............)))...(....)............  (sci:  0.320)  0.02  [[[][]][]][]
 (-28.38 = -15.47 + -12.91)  ..............((((.....))))....(((....((((((.......(((((..(..(((((.....))))............))..))))))))))).))).......................................(..........)............  (sci:  0.350)  0.01  [][][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=10
                          1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWW  40
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-29.54 = -18.91 + -10.63)  ....(((((((((((.....)))))))))......))...  (sci:  1.284)  []
@@ -4179,23 +4179,23 @@ Sampling results:
 
 ( -5.43 =  -2.23 +  -3.20)  (((((.(..........).)))))........  (sci:  0.670)  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=20
                       1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-9.07 = -9.21 +  0.14)  .......(((.((((.....)))).)))........................  (sci:  0.520)  0.70  []
 (-6.36 = -6.26 + -0.10)  .......(((.((((.....)))).))).........(......).......  (sci:  0.370)  0.30  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
                               1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-31.70 = -29.92 + -1.78)  0.80  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.910)  1.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=20
                                  1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-0.97 = -1.05 +  0.08)  0.2036722  .........................................((......))......................................................................................................................  (sci:  0.020)  0.8500000  []
 ( 0.64 =  0.56 +  0.08)  0.0142876  .........................................((......)).(((.....................................)))..........................................................................  (sci: -0.010)  0.0700000  [][]
 ( 0.00 =  0.00 +  0.00)  0.0535689  .........................................................................................................................................................................  (sci: 0.000)  0.0600000  _
 ( 3.51 =  3.65 + -0.14)  0.0001194  .......................................((.(((...)))(((((..................................).))))...))....................................................................  (sci: -0.060)  0.0200000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=40 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-14.29 = -12.33 + -1.96)  .......(((((((.......)))))))............  (sci:  0.700)  1.00  []
 
@@ -4203,50 +4203,50 @@ Sampling results:
 ( -1.33 =   0.73 + -2.06)  .(((..(..........)..))).........  (sci:  0.180)  0.98  []
 (  3.11 =   4.36 + -1.25)  .((((.(..........).)))).(......)  (sci: -0.430)  0.02  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=100 ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.15 = -9.21 +  0.06)  .......(((.((((.....)))).)))........................  (sci:  0.530)  0.99  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-4.89 = -5.31 + 0.42)  .((....(((.((((.....)))).))).......))...............  (sci:  0.300)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=37
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (22.13 = 9.88 + 12.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-20.74 = -11.54 + -9.20)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.020)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
                       1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-9.81 = -10.33 + 0.52)  .((....(((.((((.....)))).))).......))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (6.06 = 2.55 + 3.51)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (14.45 = 2.55 + 11.90)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
                        1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-10.53 = -11.05 + 0.52)  .((....(((.((((.....)))).))).......))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
                     1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (12.29 = 8.23 + 4.06)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.210)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
                          1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-23.27 = -11.47 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 (-22.85 = -11.05 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 (-22.24 = -10.44 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 (-22.13 = -10.33 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=25.9
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-34.37 = -24.15 + -10.22)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.050)  [[][][]]
 (-34.18 = -23.96 + -10.22)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.040)  [[][][]]
@@ -4377,76 +4377,76 @@ Sampling results:
 (-29.16 = -18.94 + -10.22)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.890)  [[][][]]
 (-28.96 = -18.74 + -10.22)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.880)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.42 = -9.37 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 (-21.10 = -9.05 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 (-20.54 = -8.49 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 (-20.42 = -8.37 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=37
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (23.84 = 5.59 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (24.12 = 5.87 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (25.01 = 6.76 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (25.30 = 7.05 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-32.45 = -24.15 + -8.30)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (13.28 = 9.21 + 4.07)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.240)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-10.93 = -11.05 + 0.12)  .((....(((.((((.....)))).))).......))...............  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
                     1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (10.63 = 8.12 + 2.51)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=25.9
                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-18.75 = -8.02 + -10.73)  .((....(((.((((.....)))).))).......))...............  (sci:  0.910)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-38.58 = -11.54 + -27.04)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.860)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
                          1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-22.16 = -10.23 + -11.93)  .((....(((.((((.....)))).))).......))...............  (sci:  0.930)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (21.27 = 8.24 + 13.03)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.280)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=37
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-47.76 = -17.67 + -30.09)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (25.40 = 7.15 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-47.68 = -17.67 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.840)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
                         1  uggUGGUGGMSCGCUHAMYmrGCGRSCCWaawcwuhURWWYDYSCYUUUUuG  52
 (-16.93 = -6.09 + -10.84)  .((....(((.((((.....)))).))).......))...............  (sci:  0.960)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
                      1  a---uamu-gaKHDGMYRYRHNWHNKH-guRBGGuCAAGCRGGGUGGUACCGCGKBDYY--cgCGYAYYDrGMgya---------u-GKMkcUCGUCCCYSHRHHYRrawugmag-camryarurmY-wwyggurCUKKR-aummGMMYGRRGARACWc-MYRCrmaaa  169
 (21.41 = 3.13 + 18.28)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (21.71 = 3.43 + 18.28)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (22.97 = 4.69 + 18.28)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 (23.27 = 4.99 + 18.28)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-36.56 = -26.30 + -10.26)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 (-36.49 = -26.23 + -10.26)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
@@ -4577,14 +4577,14 @@ Sampling results:
 (-31.08 = -20.82 + -10.26)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 (-31.00 = -20.74 + -10.26)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (12.67 = 9.21 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.220)  [][]
 (12.75 = 9.29 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.220)  [][]
 (13.27 = 9.81 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.230)  [][]
 (13.34 = 9.88 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.230)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=25.9
                          1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-54.16 = -24.15 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.640)  [[][][]]
 (-53.97 = -23.96 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.640)  [[][][]]
@@ -4715,19 +4715,19 @@ Sampling results:
 (-48.95 = -18.94 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.490)  [[][][]]
 (-48.75 = -18.74 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.480)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (8.66 = 3.13 + 5.53)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=17
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-31.86 = -29.90 + -1.96)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.810)  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-25.91 = -24.15 + -1.76)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
                         1  KSSUKYGURGYYYAGYu-GGY--ARRGCAYCWGSYUUUSRMSCWGAADKuCVBRGGUUCGARUCCYRKCGVDSSMR  76
 (-18.93 = -16.99 + -1.94)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.750)  [[][][]]
 
@@ -4827,7 +4827,7 @@ Sampling results:
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=abstract --allowLP=1 --grammar=macrostate '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --shapeLevel=5
 [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
 2 37 0.116656 ubox
 3 36 0.115768 ubox
 8 28 0.996211 ubox
@@ -4837,7 +4837,7 @@ Sampling results:
 14 22 0.999847 ubox
 15 21 0.985535 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
 39 102 0.969881 ubox
 40 101 0.973155 ubox
 41 100 0.97314 ubox
@@ -4858,7 +4858,7 @@ Sampling results:
 65 73 0.802461 ubox
 66 72 0.794296 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.1 --cfactor=1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.1 --cfactor=1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
 2 37 0.391038 ubox
 3 36 0.38719 ubox
 8 28 0.998441 ubox
@@ -4869,7 +4869,7 @@ Sampling results:
 14 22 0.999983 ubox
 15 21 0.965562 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
 39 102 0.992451 ubox
 40 101 0.999959 ubox
 41 100 0.99994 ubox
@@ -4886,7 +4886,7 @@ Sampling results:
 65 73 0.33438 ubox
 66 72 0.33438 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.001 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.001 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=25.9
 1 38 0.102514 ubox
 2 37 0.15176 ubox
 2 41 0.0367382 ubox
@@ -4904,7 +4904,7 @@ Sampling results:
 14 22 0.999935 ubox
 15 21 0.94684 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=17
 21 33 0.393031 ubox
 22 32 0.393031 ubox
 39 102 0.994438 ubox
@@ -4926,7 +4926,7 @@ Sampling results:
 65 73 0.766526 ubox
 66 72 0.761115 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.001 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.001 --cfactor=1.1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=25.9
 32 101 0.184943 ubox
 33 100 0.184943 ubox
 40 101 0.727135 ubox
@@ -4941,7 +4941,7 @@ Sampling results:
 54 94 0.96296 ubox
 55 93 0.936628 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
 40 101 0.788133 ubox
 41 100 0.788133 ubox
 42 51 0.578409 ubox
@@ -4956,7 +4956,7 @@ Sampling results:
 54 94 0.981261 ubox
 55 93 0.960845 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=17
 1 75 0.998643 ubox
 2 74 0.999998 ubox
 3 73 0.999999 ubox
@@ -4980,7 +4980,7 @@ Sampling results:
 55 65 0.483217 ubox
 56 64 0.48198 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.1 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.1 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=17
 3 43 0.354499 ubox
 4 42 0.353426 ubox
 5 37 0.349151 ubox
@@ -4995,7 +4995,7 @@ Sampling results:
 14 22 0.99999 ubox
 15 21 0.987887 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
 1 75 0.988386 ubox
 2 74 0.999947 ubox
 3 73 0.999988 ubox
@@ -5034,7 +5034,7 @@ Sampling results:
 56 64 0.466278 ubox
 57 62 0.00756865 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=1e-05 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=1e-05 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
 1 8 0.00499598 ubox
 1 21 0.00437749 ubox
 1 38 0.030474 ubox
@@ -5126,7 +5126,7 @@ Sampling results:
 37 52 0.0117272 ubox
 38 51 0.0117272 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.1 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=17
 15 27 0.452186 ubox
 15 36 0.346191 ubox
 16 26 0.466576 ubox
@@ -5161,7 +5161,7 @@ Sampling results:
 65 73 1.00177 ubox
 66 72 0.994533 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.1 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=37
 1 75 0.996262 ubox
 2 74 0.999974 ubox
 3 73 0.999989 ubox
@@ -5183,7 +5183,7 @@ Sampling results:
 55 65 0.999942 ubox
 56 64 0.998548 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=17
 10 117 0.0105583 ubox
 10 136 0.0105356 ubox
 12 16 0.0125595 ubox
@@ -5638,7 +5638,7 @@ Sampling results:
 157 163 0.0181813 ubox
 157 165 0.0194712 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=25.9
 2 40 0.155745 ubox
 2 41 0.165035 ubox
 2 43 0.11628 ubox
@@ -5678,7 +5678,7 @@ Sampling results:
 14 22 0.609876 ubox
 15 21 0.587678 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=mis --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=37
 4 38 0.172745 ubox
 5 37 0.249478 ubox
 6 36 0.243448 ubox
@@ -5691,7 +5691,7 @@ Sampling results:
 15 21 0.918344 ubox
 38 45 0.11349 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --temperature=37
 32 101 0.100629 ubox
 33 100 0.121387 ubox
 34 147 0.161849 ubox
@@ -5720,7 +5720,7 @@ Sampling results:
 55 93 0.696371 ubox
 56 91 0.271265 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.001 --cfactor=1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --bppmThreshold=0.001 --cfactor=1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=0.9 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=17
 1 38 0.0632898 ubox
 2 37 0.0816538 ubox
 2 40 0.0609556 ubox
@@ -5770,7 +5770,7 @@ Sampling results:
 38 45 0.146255 ubox
 45 52 0.144928 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=1e-05 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
 1 75 0.998792 ubox
 2 74 0.999999 ubox
 3 73 0.999999 ubox
@@ -5812,7 +5812,7 @@ Sampling results:
 57 62 0.0999018 ubox
 58 62 0.117401 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.001 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.001 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-150 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --temperature=25.9
 1 75 0.994858 ubox
 2 74 0.999987 ubox
 3 73 0.999996 ubox
@@ -5838,7 +5838,7 @@ Sampling results:
 56 64 0.406112 ubox
 57 62 0.0334296 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --bppmThreshold=0.01 --cfactor=1.1 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1.1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --temperature=37
 1 75 0.997831 ubox
 2 74 0.999996 ubox
 3 73 0.999997 ubox
@@ -5864,7 +5864,7 @@ Sampling results:
 55 65 0.562013 ubox
 56 64 0.561892 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=0.9 --consensus=consensus --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-200 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=25.9
 12 19 0.128295 ubox
 13 18 0.106244 ubox
 14 19 0.100154 ubox
@@ -5926,7 +5926,7 @@ Sampling results:
 150 157 0.107422 ubox
 152 157 0.245872 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ROOTDIR/Misc/Test-Suite/StefanStyle/t-box.aln --bppmThreshold=0.01 --cfactor=1 --consensus=mis --dotplot=dotPlot.ps --nfactor=1 --pairingFraction=-300 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --temperature=37
 12 19 0.127061 ubox
 12 157 0.111821 ubox
 13 18 0.110578 ubox

--- a/Misc/Test-Suite/StefanStyle/Truth/rnaalishapes.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/rnaalishapes.run.out
@@ -36,7 +36,7 @@
 (-56.83 = -27.27 + -29.56)  0.8768472  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-27.52 = -16.50 + -11.02)  ..............((((.....))))...........((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.360)  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
@@ -44,14 +44,14 @@
 (-20.49 = -7.49 + -13.00)  ......................................((((((.......((((........(((.....)))..................))))))))))...................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
-                       1  uggugguggcccgcucaaccggcggccca______cugau  40
+                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-13.78 = -13.95 + 0.17)  .......(((.((((.....)))).)))............  (sci:  0.600)  []
 
-                      21  ggcggccca______cugauugcgccuuuuug  52
+                      21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (  0.00 =   0.00 + 0.00)  ................................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-59.30 = -29.58 + -29.72)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
@@ -59,7 +59,7 @@
 (-22.83 = -10.16 + -12.67)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.400)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                     1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.07 = -9.21 + 0.14)  .......(((.((((.....)))).)))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
@@ -73,23 +73,23 @@
 ( 0.00 =  0.00 +  0.00)  ................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-17.53 =  -5.19 + -12.34)  ...............((((...................))))((.((....(((((......((((.....))))................)))))))))  (sci:  0.440)  [][]
 
-                        21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg____________  120
+                        21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG____________  120
 (-25.88 = -13.77 + -12.11)  ..................((((((.......(((((......((((.....))))................)))))))))))..................  (sci:  0.720)  []
 
-                        41  ggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg  140
+                        41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG  140
 (-18.34 =  -8.40 +  -9.94)  ((((.......(((((......((((.....))))................)))))))))........................................  (sci:  0.530)  []
 
-                        61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                        61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( -4.79 =  -0.24 +  -4.55)  ..((((.....))))...................((((((.((............................................)).))).)))...  (sci:  0.150)  [][]
 
-                        81  _______ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                        81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -3.86 =  -0.36 +  -3.50)  ..............((((((.((............................................)).))).)))............  (sci:  0.130)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
-                                1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-3.12 = -3.27 + 0.15)  0.3941977  ...........................................(((....)))....................................................................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
@@ -97,17 +97,17 @@
 (-7.46 = -7.33 + -0.13)  0.3566348  ......................................((((((.......((((.....................................))))))))))...................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                   1  uggugguggcccgcucaaccggcggccca______cugau  40
+                                   1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-16.36 = -16.00 + -0.36)  0.6882692  .......((((((((.....))))))))............  []
 
-                                  11  ccgcucaaccggcggccca______cugauugcgccuuuu  50
+                                  11  CCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUU  50
 ( -7.65 =  -7.29 + -0.36)  0.8847149  (((((.....))))).........................  []
 
-                                  21  ggcggccca______cugauugcgccuuuuug  52
+                                  21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( -2.49 =  -1.13 + -1.36)  0.4967891  ((((..................))))......  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-26.80 = -21.51 + -5.29)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.070)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
@@ -119,19 +119,19 @@
 (-33.70 = -23.71 + -9.99)  0.6883790  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.140)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -2.26 =  -1.08 + -1.18)  0.8222531  .........(((.............)))............  []
 
-                                  11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                                  11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 ( -8.06 =  -5.60 + -2.46)  0.8100845  ...................(((((.......)))))....  []
 
-                                  21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                                  21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 ( -8.06 =  -5.60 + -2.46)  0.8827548  .........(((((.......)))))..............  []
 
-                                  31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                                  31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-15.66 = -10.41 + -5.25)  0.9439498  ((((.......))))......(((((.......)))))..  [][]
 
-                                  41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                                  41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -9.34 =  -6.51 + -2.83)  0.9714581  ...........(((((.......)))))........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
@@ -160,11 +160,11 @@
 ( -3.52 =   0.72 +  -4.24)  ........................(((((((.((.........................................)).)).)).)))............  (sci:  0.090)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-30.33 = -20.19 + -10.14)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.260)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                       1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-11.39 = -11.39 + 0.00)  ......................................((((((.......((((.....................................))))))))))...................................................................  (sci:  0.150)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
@@ -211,28 +211,28 @@
 ( 0.00 =  0.00 + 0.00)  .......................................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                    1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-18.41 =  -7.04 + -11.37)  0.0397469  ........................................((((.(....)(((((.......(((.....)))................).))))))))  (sci:  0.420)  [[][]]
 
-                                   11  _gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg__  110
+                                   11  _GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG__  110
 (-24.95 = -11.48 + -13.47)  0.0660907  ............................((((((.(....)(((((.......(((.....)))................).))))))))))........  (sci:  0.540)  [[][]]
 
-                                   21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg____________  120
+                                   21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG____________  120
 (-24.95 = -11.48 + -13.47)  0.2582300  ..................((((((.(....)(((((.......(((.....)))................).))))))))))..................  (sci:  0.610)  [[][]]
 
-                                   31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                                   31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-24.95 = -11.48 + -13.47)  0.2798148  ........((((((.(....)(((((.......(((.....)))................).))))))))))............................  (sci:  0.630)  [[][]]
 
-                                   41  ggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg  140
+                                   41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG  140
 (-18.41 =  -7.04 + -11.37)  0.3538857  ((((.(....)(((((.......(((.....)))................).))))))))........................................  (sci:  0.480)  [[][]]
 
-                                   51  cgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccg  150
+                                   51  CGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCG  150
 ( -7.27 =  -0.69 +  -6.58)  0.2001368  .(((((.......(((.....)))................).))).).....................................................  (sci:  0.190)  []
 
-                                   61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                                   61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( -3.08 =   0.98 +  -4.06)  0.1008486  ...(((.....)))....................(((.((...................................................)).)))...  (sci:  0.080)  [][]
 
-                                   71  _gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                   71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -2.82 =   0.28 +  -3.10)  0.2272295  ........................(((.((...................................................)).)))............  (sci:  0.080)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
@@ -240,17 +240,17 @@
 (-28.46 = -19.26 + -9.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.210)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-39.63 = -28.64 + -10.99)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                       1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.08 = -1.90 + -1.18)  .........(((.............)))............  []
 
-                      31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                      31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-14.30 = -9.05 + -5.25)  ((((.......))))......(((((.......)))))..  [][]
 
-                      61  aaucccaucgaacgcg  76
+                      61  AAUCCCAUCGAACGCG  76
 (  0.00 =  0.00 +  0.00)  ................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
@@ -258,7 +258,7 @@
 (-8.45 = -8.36 + -0.09)  .......((..((((.....))))..))........................  (sci:  0.400)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
-                                1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-1.82 = -1.88 + 0.06)  0.1150177  ..........................................((.....))......................................................................................................................  (sci:  0.030)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
@@ -266,19 +266,19 @@
 (-12.40 = -10.24 + -2.16)  .......(((((((.......)))))))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
-                       1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.11 = -2.99 + -0.12)  .........((((...........))))............  (sci:  0.450)  []
 
-                      11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                      11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 ( -7.04 = -5.14 + -1.90)  ...................(((((.......)))))....  (sci:  0.810)  []
 
-                      21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                      21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 ( -7.04 = -5.14 + -1.90)  .........(((((.......)))))..............  (sci:  0.890)  []
 
-                      31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                      31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-13.35 = -9.22 + -4.13)  ((((.......))))......(((((.......)))))..  (sci:  1.190)  [][]
 
-                      41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                      41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -7.89 = -5.65 + -2.24)  ...........(((((.......)))))........  (sci:  0.980)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
@@ -290,15 +290,15 @@
 (-46.87 = -17.23 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  2.140)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
-                                 1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                 1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-7.76 = -7.66 + -0.10)  0.5906838  .......((..((((.....))))..))........................  (sci:  0.320)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
-                                    1  uggugguggcccgcucaaccggcggccca______cugau  40
+                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-25.31 = -14.94 + -10.37)  0.5861077  .......((((((((.....))))))))............  (sci:  1.300)  []
 (-24.86 = -13.40 + -11.46)  0.2741686  ...(((.((((((((.....)))))))).......)))..  (sci:  1.270)  []
 
-                                   21  ggcggccca______cugauugcgccuuuuug  52
+                                   21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( -3.57 =  -0.65 +  -2.92)  0.6002689  ((((..................))))......  (sci:  0.640)  []
 ( -3.04 =  -1.22 +  -1.82)  0.2492340  (((((..............)))))........  (sci:  0.540)  []
 
@@ -419,28 +419,28 @@
 ( -0.62 =   2.57 +  -3.19)  ..............(((((....................................................)).)))............  (sci:  0.030)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-41.94 = -32.74 + -9.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-22.27 = -10.16 + -12.11)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  []
 (-22.14 =  -9.72 + -12.42)  ......................................((((((.......((((((.....((((.....))))..............)).))))))))))...................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
-                       1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -1.91 = -0.84 + -1.07)  .........(((.............)))............  []
 
-                      11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                      11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 ( -7.35 = -5.14 + -2.21)  ...................(((((.......)))))....  []
 
-                      21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                      21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 ( -7.35 = -5.14 + -2.21)  .........(((((.......)))))..............  []
 
-                      31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                      31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-13.99 = -9.22 + -4.77)  ((((.......))))......(((((.......)))))..  [][]
 
-                      41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                      41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -8.22 = -5.65 + -2.57)  ...........(((((.......)))))........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
@@ -484,7 +484,7 @@
 ( -4.26 =   0.55 +  -4.81)  0.0857496  ........................(((((((...............................................)).)).)))............  (sci:  0.120)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-7.59 = -7.52 + -0.07)  .......................................(((((.......((((.....................................)))))))))....................................................................  []
 (-6.82 = -6.89 +  0.07)  .......................................(((((.......(((.......................................))))))))....................................................................  []
 (-6.65 = -6.66 +  0.01)  .......................................(((((....................................................)))))....................................................................  []
@@ -499,13 +499,13 @@
 (-17.53 = -15.32 + -2.21)  ......................................((((((.......((((((.....((((.....))))..............)).))))))))))...................................................................  (sci:  0.240)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                      1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                      1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 (-3.89 = -3.26 + -0.63)  .........(((.............)))............  []
 
-                     21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                     21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 (-7.04 = -6.55 + -0.49)  .........(((((.......)))))..............  []
 
-                     41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                     41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-7.48 = -7.32 + -0.16)  ...........(((((.......)))))........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
@@ -515,7 +515,7 @@
 (-21.08 = -19.30 + -1.78)  0.1278285  (((((((..(((.............)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.840)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                     1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-8.77 = -8.90 + 0.13)  .......(((.((((.....)))).)))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
@@ -543,7 +543,7 @@
 (0.00 = 0.00 + 0.00)  1.0000000  ...................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-29.48 = -20.32 + -9.16)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.120)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
@@ -647,30 +647,30 @@
 ( 0.00 =  0.00 +  0.00)  .........................................................................................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
-                                    1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-43.89 = -32.74 + -11.15)  0.1160172  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
-                                1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-0.75 = -0.85 + 0.10)  0.0900757  ..........................................((.....))......................................................................................................................  (sci:  0.010)  []
 (-0.43 = -0.53 + 0.10)  0.0537029  ..........................................(((...)))......................................................................................................................  (sci:  0.010)  []
 ( 0.00 =  0.00 + 0.00)  0.0267299  .........................................................................................................................................................................  (sci: 0.000)  _
 ( 0.17 =  0.12 + 0.05)  0.0204102  ...................................................((((.....................................)))).........................................................................  (sci: 0.000)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
-                       1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -1.91 = -0.84 + -1.07)  .........(((.............)))............  (sci:  0.280)  []
 
-                      11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                      11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 ( -7.35 = -5.14 + -2.21)  ...................(((((.......)))))....  (sci:  0.850)  []
 
-                      21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                      21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 ( -7.35 = -5.14 + -2.21)  .........(((((.......)))))..............  (sci:  0.920)  []
 
-                      31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                      31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-13.99 = -9.22 + -4.77)  ((((.......))))......(((((.......)))))..  (sci:  1.240)  [][]
 
-                      41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                      41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -8.22 = -5.65 + -2.57)  ...........(((((.......)))))........  (sci:  1.010)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
@@ -678,26 +678,26 @@
 (-11.93 = -12.12 + 0.19)  0.3768381  .......(((.((((.....)))).)))........................  (sci:  0.560)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
-                        1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-18.31 = -17.92 + -0.39)  .......((((((((.....))))))))........................  []
 (-18.11 = -15.95 + -2.16)  .......(((((((.......)))))))........................  []
 (-17.66 = -15.18 + -2.48)  .......((((((((.....)))))))).........(......).......  [][]
 (-17.46 = -13.21 + -4.25)  .......(((((((.......))))))).........(......).......  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                        1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                        1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-11.49 = -11.39 + -0.10)  ......................................((((((.......((((.....................................))))))))))...................................................................  []
 (-11.36 = -11.27 + -0.09)  ......................................((((((.......(((((..................................).))))))))))...................................................................  []
 (-10.95 = -11.04 +  0.09)  ......................................((((((.......((((.........((.....))...................))))))))))...................................................................  []
 (-10.66 = -10.73 +  0.07)  ......................................((((((.......(((.......................................)))))))))...................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
-                                   1  uggugguggcccgcucaaccggcggccca______cugau  40
+                                   1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-15.97 = -14.01 + -1.96)  0.0143560  .......(((((((.......)))))))............  []
 (-15.71 = -15.33 + -0.38)  0.2740186  .......((((((((.....))))))))............  []
 (-15.07 = -13.05 + -2.02)  0.0191458  ...(((.(((((((.......))))))).......)))..  []
 
-                                  11  ccgcucaaccggcggccca______cugauugcgccuuuu  50
+                                  11  CCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUU  50
 ( -7.98 =  -6.02 + -1.96)  0.0149635  ((((.......)))).........................  []
 ( -7.92 =  -4.05 + -3.87)  0.0134692  ((((.......))))............(......).....  [][]
 ( -7.73 =  -7.35 + -0.38)  0.2856138  (((((.....))))).........................  []
@@ -707,7 +707,7 @@
 ( -7.42 =  -7.04 + -0.38)  0.1557104  .((((.....))))..........................  []
 ( -7.35 =  -5.07 + -2.28)  0.1401604  .((((.....)))).............(......).....  [][]
 
-                                  21  ggcggccca______cugauugcgccuuuuug  52
+                                  21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( -2.74 =  -0.65 + -2.09)  0.1079739  ((((..(..........)..))))........  []
 ( -2.57 =   0.89 + -3.46)  0.1517118  (((((..(.........)..).))))......  []
 ( -2.50 =  -0.41 + -2.09)  0.0860503  .(((..(..........)..))).........  []
@@ -716,81 +716,81 @@
 ( -1.94 =  -0.59 + -1.35)  0.1122729  .((((.(..........).)))).........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
-                                   1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                                   1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( -6.40 =  -6.30 + -0.10)  0.1957547  ........................................((((.......((((.....................................))))))))  []
 ( -6.13 =  -6.15 +  0.02)  0.1070419  ........................................((((.......(((((........((.....)).................).))))))))  []
 ( -6.04 =  -5.92 + -0.12)  0.1034204  ........................................((((.......(((((..................................).))))))))  []
 ( -5.87 =  -5.91 +  0.04)  0.0684575  ........................................((((.......((((.........((.....))...................))))))))  []
 
-                                  11  _gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg__  110
+                                  11  _GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG__  110
 (-12.59 = -12.49 + -0.10)  0.2077706  ............................((((((.......((((.....................................))))))))))........  []
 (-12.33 = -12.35 +  0.02)  0.1136125  ............................((((((.......(((((........((.....)).................).))))))))))........  []
 (-12.23 = -12.11 + -0.12)  0.1097687  ............................((((((.......(((((..................................).))))))))))........  []
 (-12.06 = -12.10 +  0.04)  0.0726595  ............................((((((.......((((.........((.....))...................))))))))))........  []
 
-                                  21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg____________  120
+                                  21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG____________  120
 (-12.59 = -12.49 + -0.10)  0.2227956  ..................((((((.......((((.....................................))))))))))..................  []
 (-12.33 = -12.35 +  0.02)  0.1218284  ..................((((((.......(((((........((.....)).................).))))))))))..................  []
 (-12.23 = -12.11 + -0.12)  0.1177067  ..................((((((.......(((((..................................).))))))))))..................  []
 (-12.06 = -12.10 +  0.04)  0.0779139  ..................((((((.......((((.........((.....))...................))))))))))..................  []
 
-                                  31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                                  31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-12.59 = -12.49 + -0.10)  0.2369158  ........((((((.......((((.....................................))))))))))............................  []
 (-12.33 = -12.35 +  0.02)  0.1295496  ........((((((.......(((((........((.....)).................).))))))))))............................  []
 (-12.23 = -12.11 + -0.12)  0.1251666  ........((((((.......(((((..................................).))))))))))............................  []
 (-12.06 = -12.10 +  0.04)  0.0828519  ........((((((.......((((.........((.....))...................))))))))))............................  []
 
-                                  41  ggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg  140
+                                  41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG  140
 ( -7.49 =  -7.39 + -0.10)  0.2520483  ((((.......((((.....................................))))))))........................................  []
 ( -7.22 =  -7.24 +  0.02)  0.1378235  ((((.......(((((........((.....)).................).))))))))........................................  []
 ( -7.13 =  -7.01 + -0.12)  0.1331610  ((((.......(((((..................................).))))))))........................................  []
 ( -6.96 =  -7.00 +  0.04)  0.0881435  ((((.......((((.........((.....))...................))))))))........................................  []
 
-                                  51  cgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccg  150
+                                  51  CGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCG  150
 ( -2.09 =  -1.98 + -0.11)  0.3016881  .((((.....................................))))......................................................  []
 ( -1.81 =  -1.83 +  0.02)  0.1649680  .(((((........((.....)).................).))))......................................................  []
 ( -1.72 =  -1.60 + -0.12)  0.1593863  .(((((..................................).))))......................................................  []
 ( -1.56 =  -1.59 +  0.03)  0.1055032  .((((.........((.....))...................))))......................................................  []
 
-                                  61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                                  61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( -0.30 =  -0.21 + -0.09)  0.2771475  ...................................(((.((...............................................)).)))......  []
 (  0.00 =   0.00 +  0.00)  0.2357807  ....................................................................................................  _
 (  0.41 =   0.23 +  0.18)  0.1062904  ...................................(((.....................................................)))......  []
 (  0.58 =   0.67 + -0.09)  0.0799789  ...................................(((..(...............................................)..)))......  []
 (  0.58 =   0.53 +  0.05)  0.0533367  ....((.....))......................(((.((...............................................)).)))......  [][]
 
-                                  71  _gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                  71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -0.30 =  -0.21 + -0.09)  0.3333501  .........................(((.((...............................................)).)))...............  []
 (  0.00 =   0.00 +  0.00)  0.2835931  ...................................................................................................  _
 (  0.41 =   0.23 +  0.18)  0.1278445  .........................(((.....................................................)))...............  []
 (  0.58 =   0.67 + -0.09)  0.0961977  .........................(((..(...............................................)..)))...............  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-31.59 = -18.90 + -12.69)  .((((((((((((((.....)))))))))..........)))))........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
-                                 1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                 1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-7.69 = -7.66 + -0.03)  0.6008547  .......((..((((.....))))..))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
-                                1  uggugguggcccgcucaaccggcggccca______cugau  40
+                                1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-8.62 = -8.90 + 0.28)  0.8959865  .......(((.((((.....)))).)))............  []
 
-                               21  ggcggccca______cugauugcgccuuuuug  52
+                               21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( 0.00 =  0.00 + 0.00)  0.9738398  ................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                       1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                       1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( -4.06 =  -4.35 + 0.29)  ........................................((((.......((((.....................................))))))))  (sci:  0.090)  []
 
-                      31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                      31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-10.10 = -10.21 + 0.11)  ........((((((.......((((.....................................))))))))))............................  (sci:  0.260)  []
 
-                      61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                      61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 (  0.00 =   0.00 + 0.00)  ....................................................................................................  (sci: 0.000)  _
 
-                      91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                      91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (  0.00 =   0.00 + 0.00)  ...............................................................................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
@@ -804,44 +804,44 @@
 (-29.88 = -16.56 + -13.32)  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  (sci:  0.390)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
-                                    1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -9.68 =  -4.72 +  -4.96)  0.8268605  .........((((...........))))............  (sci:  1.000)  []
 
-                                   31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                                   31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-25.86 = -12.44 + -13.42)  0.9935328  ((((.......))))......(((((.......)))))..  (sci:  1.770)  [][]
 
-                                   61  aaucccaucgaacgcg  76
+                                   61  AAUCCCAUCGAACGCG  76
 (  0.00 =   0.00 +   0.00)  0.9998100  ................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-0.71 = -0.85 +  0.14)  ..........................................((.....)).................................................  []
 (-0.49 = -0.73 +  0.24)  ..........................................((.....))((((.....................................))))....  [][]
 ( 0.00 =  0.00 +  0.00)  ....................................................................................................  _
 
-                     21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg____________  120
+                     21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG____________  120
 (-0.71 = -0.85 +  0.14)  ......................((.....)).....................................................................  []
 (-0.49 = -0.73 +  0.24)  ......................((.....))((((.....................................))))........................  [][]
 (-0.13 =  0.15 + -0.28)  ...................((.((.....))((((.....................................))))...))...................  [[][]]
 ( 0.00 =  0.00 +  0.00)  ....................................................................................................  _
 
-                     41  ggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg  140
+                     41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG  140
 (-0.71 = -0.85 +  0.14)  ..((.....)).........................................................................................  []
 (-0.49 = -0.73 +  0.24)  ..((.....))((((.....................................))))............................................  [][]
 ( 0.00 =  0.00 +  0.00)  ....................................................................................................  _
 
-                     61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                     61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  ....................................................................................................  _
 
-                     81  _______ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                     81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  .........................................................................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
-                                    1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-21.98 = -10.16 + -11.82)  0.0280410  ......................................((((((.......(((((......((((.....))))................)))))))))))...................................................................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
-                                    1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.36 = -11.10 + -10.26)  0.1582262  .......((((((((.....))))))))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
@@ -855,11 +855,11 @@
 (  0.00 =   0.00 +  0.00)  1.0000000  ................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                    1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-23.71 = -13.45 + -10.26)  0.1620205  .......((((((((.....))))))))........................  (sci:  1.100)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
-                                   1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                   1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-13.96 = -13.61 + -0.35)  0.2324163  .......((((((((.....))))))))........................  (sci:  0.800)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
@@ -867,54 +867,54 @@
 (-15.97 = -14.01 + -1.96)  .......(((((((.......)))))))........................  (sci:  0.640)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                       1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                       1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.26 = -3.12 + -0.14)  .........((((...........))))............  (sci:  0.500)  []
 
-                      31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                      31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-12.77 = -9.05 + -3.72)  ((((.......))))......(((((.......)))))..  (sci:  1.180)  [][]
 
-                      61  aaucccaucgaacgcg  76
+                      61  AAUCCCAUCGAACGCG  76
 (  0.00 =  0.00 +  0.00)  ................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-21.28 = -19.50 + -1.78)  0.7687765  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                        1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.43 = -9.90 + -11.53)  .......((((((((.....))))))))........................  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
-                     1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-8.67 = -8.90 + 0.23)  .......(((.((((.....)))).)))........................  (sci:  0.520)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                 1  uggugguggcccgcucaaccggcggccca______cugau  40
+                                 1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-5.95 = -5.91 + -0.04)  0.6704657  .......((..((((.....))))..))............  []
 
-                                11  ccgcucaaccggcggccca______cugauugcgccuuuu  50
+                                11  CCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUU  50
 (-4.42 = -4.24 + -0.18)  0.8772379  .((((.....))))..........................  []
 
-                                21  ggcggccca______cugauugcgccuuuuug  52
+                                21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( 0.00 =  0.00 +  0.00)  0.9593508  ................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
-                                 1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-2.94 = -3.37 +  0.43)  0.2177205  .........................................(((.(.....((((.....................................))))))))  []
 (-2.18 = -2.48 +  0.30)  0.0570744  .........................................((......))((((.....................................))))....  [][]
 
-                                31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                                31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-2.94 = -3.37 +  0.43)  0.1421043  ...........(((.(.....((((.....................................))))))))..............................  []
 (-2.18 = -2.48 +  0.30)  0.0372520  ...........((......))((((.....................................))))..................................  [][]
 
-                                61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                                61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  0.9965445  ....................................................................................................  _
 
-                                91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  0.9969431  ...............................................................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-40.67 = -30.49 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
@@ -943,46 +943,46 @@
 (-20.40 =  -8.23 + -12.17)  0.0115462  .......((((((((.....)))))))).........(......).......  (sci:  1.180)  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-48.26 = -21.51 + -26.75)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.920)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                    1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                                    1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -9.98 =  -4.39 +  -5.59)  0.3111074  .........((((...........))))............  []
 
-                                   11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                                   11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 (-16.98 =  -6.67 + -10.31)  0.2231052  (((...........)))..(((((.......)))))....  [][]
 
-                                   21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                                   21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 (-13.89 =  -6.70 +  -7.19)  0.2384925  .........(((((.......)))))..............  []
 
-                                   31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                                   31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-27.11 = -12.20 + -14.91)  0.3172337  ((((.......))))......(((((.......)))))..  [][]
 
-                                   41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                                   41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-15.33 =  -7.25 +  -8.08)  0.3775144  ...........(((((.......)))))........  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
-                                 1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-1.92 = -2.06 +  0.14)  0.1406524  ..........................................(((...))).................................................  []
 (-1.33 = -1.51 +  0.18)  0.0498855  ..........................................(((...))).(((.....................................))).....  [][]
 
-                                21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg____________  120
+                                21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG____________  120
 (-1.92 = -2.06 +  0.14)  0.1342043  ......................(((...))).....................................................................  []
 (-1.33 = -1.51 +  0.18)  0.0475985  ......................(((...))).(((.....................................))).........................  [][]
 
-                                41  ggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg  140
+                                41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG  140
 (-1.92 = -2.06 +  0.14)  0.1523690  ..(((...))).........................................................................................  []
 (-1.33 = -1.51 +  0.18)  0.0540410  ..(((...))).(((.....................................))).............................................  [][]
 
-                                61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                                61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  0.9815758  ....................................................................................................  _
 
-                                81  _______ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                81  _______GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  0.9812828  .........................................................................................  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-31.70 = -29.92 + -1.78)  0.8044733  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
@@ -990,31 +990,31 @@
 (-34.22 = -27.71 + -6.51)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --absoluteDeviation=1 --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 
-                     21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                     21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 (-5.42 = -3.84 + -1.58)  ..................((((.......)))).......  (sci:  0.490)  []
 
-                     41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                     41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 (-2.98 = -0.09 + -2.89)  .((......))(((.........)))..............  (sci:  0.350)  [][]
 (-2.95 = -1.05 + -1.90)  .((......)).............................  (sci:  0.340)  []
 
-                     61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                     61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 ( 0.76 =  1.08 + -0.32)  ..((((.....)))).........................  (sci: -0.120)  []
 
-                     81  _______ggcg_ucguccccgcgccugg____________  120
+                     81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 ( 0.98 =  2.13 + -1.15)  .............((....))...................  (sci: -0.190)  []
 
-                    101  gcgccugg________________g_u________cuggg  140
+                    101  GCGCCUGG________________G_U________CUGGG  140
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 
-                    121  ____g_u________cuggg_____gcccgaggagaca__  160
+                    121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  _
 
-                    141  _____gcccgaggagaca__acgcg____  169
+                    141  _____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  .............................  (sci: 0.000)  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --absoluteDeviation=1 --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
@@ -1022,7 +1022,7 @@
 (-28.62 = -27.71 + -0.91)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
-                              1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                              1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-18.23 = -7.24 + -10.99)  0.48  ......................................((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  (sci:  0.350)  0.96  []
 (-15.52 = -4.45 + -11.07)  0.01  ..............(((.......)))...........((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  (sci:  0.300)  0.03  [][]
 (-15.57 = -3.09 + -12.48)  0.01  ......................................((((((((....))(((((......(((.....)))...............)).))).))))))...................................................................  (sci:  0.300)  0.01  [[][]]
@@ -1030,7 +1030,7 @@
 ( -1.97 =  6.58 +  -8.55)  0.00  ...........(((.((((...................)))).(((....)))..........)))............................(((.((...................................................)).)))............  (sci:  0.040)  0.00  [[][]][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
-                                    1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                                    1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-29.36 = -16.90 + -12.46)  0.4454466  .(((((.((((((((.....))))))))...........)))))........  (sci:  1.270)  1.0000000  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
@@ -1045,27 +1045,27 @@
 ( 2.09 =  2.75 + -0.66)  ((..((...............))..)).....  0.06  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
-                                   1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                                   1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-14.77 = -1.69 + -13.08)  0.2260705  ...............((((...................))))((.((....((((........(((.....)))..................))))))))  0.6212863  [][]
 (-14.59 = -3.91 + -10.68)  0.1676597  ........................................((((.......((((........(((.....)))..................))))))))  0.3642045  []
 (-12.72 = -0.67 + -12.05)  0.0071273  ...............((((...................))))(((...)))((((........(((.....)))..................))))....  0.0140979  [][][]
 (-10.16 =  3.53 + -13.69)  0.0000967  .............((((((...................))))(((...)))((((........(((.....)))..................))))))..  0.0004112  [[][][]]
 
-                                  31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                                  31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-22.28 = -9.28 + -13.00)  0.4267972  ........((((((.......((((........(((.....)))..................))))))))))............................  1.0000000  []
 ( -8.70 =  3.25 + -11.95)  0.0000000  .(((........(((...)))((((........(((.....)))..................))))..))).............................  0.0000000  [[][]]
 ( -3.80 =  2.65 +  -6.45)  0.0000000  ((.......((.(((...))).)))).......(((.....)))........................................................  0.0000000  [][]
 ( -2.80 =  5.66 +  -8.46)  0.0000000  ((.......((.(((...))).)))).......(((.....)))...................((....)).............................  0.0000000  [][][]
 
-                                  61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                                  61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( -2.65 =  0.76 +  -3.41)  0.4553044  ..................................(((.((...................................................)).)))...  0.7607262  []
 ( -1.72 =  2.75 +  -4.47)  0.0940248  ...(((.....)))....................(((.((...................................................)).)))...  0.2392738  [][]
 
-                                  91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                  91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -2.65 =  0.76 +  -3.41)  0.5976160  ....(((.((...................................................)).)))............  1.0000000  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-32.37 = -21.17 + -11.20)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.260)  0.9876815  [[][][]]
 (-29.69 = -19.67 + -10.02)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  0.0123185  [[][]]
 
@@ -1088,7 +1088,7 @@
 (-52.06 = -22.34 + -29.72)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  2.170)  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-64.02 = -34.38 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
@@ -1096,10 +1096,10 @@
 (-61.06 = -34.38 + -26.68)  0.15  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                         1  uggugguggcccgcucaaccggcggccca______cugau  40
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-26.22 = -13.80 + -12.42)  ...((((((((((((.....)))))))))......)))..  (sci:  1.580)  1.00  []
 
-                        31  _____cugauugcgccuuuuug  52
+                        31  _____CUGAUUGCGCCUUUUUG  52
 (  0.00 =   0.00 +   0.00)  ......................  (sci: 0.000)  0.89  _
 (  1.78 =   3.10 +  -1.32)  ......((....))........  (sci: -6.190)  0.11  []
 
@@ -1135,7 +1135,7 @@
 (-18.28 = -17.92 + -0.36)  .......((((((((.....))))))))........................  1.0000000  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=0.9 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
-                              1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                              1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-26.99 = -25.21 + -1.78)  0.83  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.910)  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
@@ -1156,7 +1156,7 @@
 (-24.90 = -13.23 + -11.67)  0.0067193  .(((((.((((((((.....))))))))...........)))))(......)  (sci:  1.080)  0.0157450  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
-                               1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                               1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-49.92 = -17.40 + -32.52)  0.63  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
@@ -1172,58 +1172,58 @@
 (-27.19 = -18.95 + -8.24)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.0167330  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
-                      1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.71 = -9.85 +  0.14)  .......(((.((((.....)))).)))........................  (sci:  0.560)  0.99  []
 (-6.43 = -6.33 + -0.10)  .......(((.((((.....)))).))).........(......).......  (sci:  0.370)  0.01  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-38.31 = -28.13 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.130)  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.93  _
 ( 2.13 =  2.04 +  0.09)  ................................(......)  (sci: -0.110)  0.07  []
 ( 4.30 =  4.08 +  0.22)  ..............(.....)...........(......)  (sci: -0.220)  0.00  [][]
 
-                     31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg  70
+                     31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG  70
 (-4.05 = -4.24 +  0.19)  .............(((....))).................  (sci:  0.230)  0.79  []
 (-2.81 = -3.33 +  0.52)  .............(((....))).((........))....  (sci:  0.160)  0.19  [][]
 (-1.19 = -1.78 +  0.59)  .....(......)(((....))).((........))....  (sci:  0.070)  0.01  [][][]
 (-0.75 = -1.09 +  0.34)  ..(..(......)(((....)))..........)......  (sci:  0.040)  0.01  [[][]]
 
-                     61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                     61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.83  _
 ( 1.03 =  0.74 +  0.29)  ....((.....))...........................  (sci: -0.100)  0.17  []
 ( 3.33 =  3.15 +  0.18)  ....((.....)).....................(....)  (sci: -0.330)  0.00  [][]
 
-                     91  g_ucguccccgcgccugg________________g_u___  130
+                     91  G_UCGUCCCCGCGCCUGG________________G_U___  130
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.98  _
 ( 2.31 =  2.42 + -0.11)  ....(....)..............................  (sci: -0.220)  0.02  []
 
-                    121  ____g_u________cuggg_____gcccgaggagaca__  160
+                    121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.98  _
 ( 2.29 =  2.46 + -0.17)  .........................(..........)...  (sci: -0.200)  0.02  []
 ( 7.29 =  7.37 + -0.08)  .....(...........).......(..........)...  (sci: -0.620)  0.00  [][]
 
-                    151  aggagaca__acgcg____  169
+                    151  AGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  ...................  (sci: 0.000)  1.00  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-21.79 =  -7.13 + -14.66)  ..............((.((.(((.......)))).)..))((((.......(((((..(..(((((.....))))............))..)))))))))  0.8412972  [][]
 
-                        31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u___  130
+                        31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U___  130
 (-27.89 = -14.06 + -13.83)  .(((.(..((((((.......(((((..(..(((((.....))))............))..)))))))))))))))........................  0.9404893  []
 
-                        61  _cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__  160
+                        61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( -4.63 =   1.31 +  -5.94)  ..((((.....))))...................(((((((.((.........................................)).)).)).)))...  0.9101398  [][]
 
-                        91  g_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                        91  G_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( -3.74 =   1.17 +  -4.91)  ....(((((((.((.........................................)).)).)).)))............  0.9999965  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-58.28 = -28.64 + -29.64)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.770)  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
@@ -1304,7 +1304,7 @@
 (  2.03 =   6.05 +  -4.02)  .......(.....)(((.((...................................................)).)))............  (sci: -0.080)  0.00  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-34.13 = -27.71 + -6.42)  0.7340125  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.150)  1.0000000  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=mis --lowProbFilter=0.01 --nfactor=1.1 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
@@ -1313,21 +1313,21 @@
 (-20.40 = -18.99 + -1.41)  (((((((......................(((((.......))))).....(((((.......)))))))))))).  (sci:  0.810)  0.0156687  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                              1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                              1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 ( -3.96 =  -3.26 + -0.70)  0.88  .........(((.............)))............  1.00  []
 
-                             11  cucagc__ggu__agagcaccaggcuuucacccagaaagu  50
+                             11  CUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGU  50
 ( -6.01 =  -6.03 +  0.02)  0.18  ....((..........)).(((((.......)))))....  0.56  [][]
 ( -7.09 =  -6.55 + -0.54)  0.39  ...................(((((.......)))))....  0.43  []
 ( -4.11 =  -3.00 + -1.11)  0.00  ..(......((.....)).(((((.......)))))..).  0.01  [[][]]
 
-                             21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                             21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 ( -7.09 =  -6.55 + -0.54)  0.85  .........(((((.......)))))..............  1.00  []
 
-                             31  caggcuuucacccagaaagucacggguucgaaucccaucg  70
+                             31  CAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCG  70
 (-12.93 = -12.21 + -0.72)  0.93  ((((.......))))......(((((.......)))))..  1.00  [][]
 
-                             41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                             41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 ( -7.50 =  -7.32 + -0.18)  0.96  ...........(((((.......)))))........  1.00  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=mis --lowProbFilter=0.01 --nfactor=0.9 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
@@ -1350,7 +1350,7 @@
 ( -1.20 =   0.03 + -1.23)  0.0818976  ...............(((.((.((.........................................)).)).)))...............  0.9957507  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=20
-                         1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                         1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-55.59 = -25.19 + -30.39)  (((((((..((((.((...))...)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 (-56.83 = -27.27 + -29.56)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -1374,59 +1374,59 @@ Sampling results:
 (0.85 = 0.58 + 0.27)  ..........................................(((...)))((((.....................................)))).........................................................................  (sci: -0.010)  0.18  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.80  _
 ( 1.86 =  2.00 + -0.14)  ..............((((.....)))).............  (sci: -0.170)  0.20  []
 
-                     11  _gcggccgcgcgucggc_g_gggg_caagcggggugguac  50
+                     11  _GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUAC  50
 (-1.19 =  1.25 + -2.44)  ....(((.(((.................))).))).....  (sci:  0.110)  0.86  []
 ( 0.46 =  6.47 + -6.01)  .....((((.(((.......))).....)))).((...))  (sci: -0.040)  0.11  [][]
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.03  _
 
-                     21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                     21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 (-6.08 =  0.26 + -6.34)  ..................((.((......)))).......  (sci:  0.610)  0.95  []
 (-3.41 =  3.79 + -7.20)  (((.......))).....((.((......)))).......  (sci:  0.340)  0.05  [][]
 
-                     31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg  70
+                     31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG  70
 (-6.08 =  0.26 + -6.34)  ........((.((......)))).................  (sci:  0.680)  0.81  []
 (-5.00 =  2.24 + -7.24)  ........((.((......)))).((((....))))....  (sci:  0.560)  0.19  [][]
 
-                     41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                     41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 (-4.95 =  0.27 + -5.22)  ...(((....))).........((((.....)))).....  (sci:  0.670)  0.81  [][]
 (-4.54 = -0.48 + -4.06)  ...(((....)))...........................  (sci:  0.610)  0.19  []
 
-                     51  cgcggcgcu__cgcgcaccg_gcg_____________ggc  90
+                     51  CGCGGCGCU__CGCGCACCG_GCG_____________GGC  90
 (-2.39 =  0.50 + -2.89)  ((((.......)))).........................  (sci:  0.320)  0.99  []
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.01  _
 
-                     61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                     61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 (-0.42 =  0.74 + -1.16)  ..((((.....)))).........................  (sci:  0.090)  0.70  []
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.30  _
 
-                     71  _gcg_____________ggcg_ucguccccgcgccugg__  110
+                     71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG__  110
 ( 0.08 =  1.98 + -1.90)  ......................(((....)))........  (sci: -0.020)  0.56  []
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.44  _
 
-                     81  _______ggcg_ucguccccgcgccugg____________  120
+                     81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 ( 0.08 =  1.98 + -1.90)  ............(((....)))..................  (sci: -0.020)  0.54  []
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.46  _
 
-                     91  g_ucguccccgcgccugg________________g_u___  130
+                     91  G_UCGUCCCCGCGCCUGG________________G_U___  130
 ( 0.08 =  1.98 + -1.90)  ..(((....)))............................  (sci: -0.020)  0.54  []
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.46  _
 
-                    101  gcgccugg________________g_u________cuggg  140
+                    101  GCGCCUGG________________G_U________CUGGG  140
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  1.00  _
 
-                    111  ______________g_u________cuggg_____gcccg  150
+                    111  ______________G_U________CUGGG_____GCCCG  150
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.99  _
 ( 2.92 =  3.34 + -0.42)  ...........................(((......))).  (sci: -0.470)  0.01  []
 
-                    121  ____g_u________cuggg_____gcccgaggagaca__  160
+                    121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 +  0.00)  ........................................  (sci: 0.000)  0.99  _
 ( 2.92 =  3.34 + -0.42)  .................(((......)))...........  (sci: -0.590)  0.01  []
 
-                    131  _____cuggg_____gcccgaggagaca__acgcg____  169
+                    131  _____CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 +  0.00)  .......................................  (sci: 0.000)  0.99  _
 ( 5.19 =  4.95 +  0.24)  .......((........))....................  (sci: -1.460)  0.01  []
 
@@ -1563,7 +1563,7 @@ Sampling results:
 (-29.68 = -16.99 + -12.69)  .((((((((((((((.....)))))))))..........)))))........  (sci:  1.400)  1.0000000  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=10
-                            1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                            1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  0.75  ........................................  (sci: -0.000)  _
 ( 2.43 =  3.12 + -0.69)  0.01  ....................((.........)).......  (sci: -0.187)  []
@@ -1671,7 +1671,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.75  ........................................  (sci: 0.000)  0.70  _
 ( 1.33 =  2.63 + -1.30)  0.09  .................((...................))  (sci: -0.100)  0.30  []
 
-                           11  _gcggccgcgcgucggc_g_gggg_caagcggggugguac  50
+                           11  _GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUAC  50
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-1.17 =  0.49 + -1.66)  0.26  ....(((.(((.................))).))).....  (sci:  0.095)  []
 (-1.17 =  0.49 + -1.66)  0.26  ....(((.(((.................))).))).....  (sci:  0.095)  []
@@ -1780,7 +1780,7 @@ Sampling results:
 (-0.10 =  3.89 + -3.99)  0.05  .....((((...................)))).((...))  (sci:  0.010)  0.09  [][]
 ( 0.00 =  0.00 +  0.00)  0.04  ........................................  (sci: 0.000)  0.04  _
 
-                           21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                           21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-5.35 = -2.07 + -3.29)  0.04  .......................(((....))).......  (sci:  0.483)  []
 (-6.72 = -3.03 + -3.69)  0.35  ..................((((.......)))).......  (sci:  0.606)  []
@@ -1888,7 +1888,7 @@ Sampling results:
 (-6.72 = -3.03 + -3.69)  0.35  ..................((((.......)))).......  (sci:  0.610)  0.96  []
 (-4.14 =  1.65 + -5.79)  0.01  ((.........)).....((.((......)))).......  (sci:  0.370)  0.04  [][]
 
-                           31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg  70
+                           31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG  70
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-6.26 = -2.09 + -4.17)  0.08  ........((((.......)))).((((....))))....  (sci:  0.571)  [][]
 (-6.57 = -1.47 + -5.10)  0.13  ........((.((......)))).................  (sci:  0.599)  []
@@ -1997,7 +1997,7 @@ Sampling results:
 (-6.72 = -3.03 + -3.69)  0.17  ........((((.......)))).................  (sci:  0.610)  0.44  []
 (-3.97 =  1.99 + -5.96)  0.00  ..........(((((...)))(((.........))).)).  (sci:  0.360)  0.03  [[][]]
 
-                           41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                           41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-3.40 = -0.04 + -3.37)  0.00  .((......))...(((......)))..............  (sci:  0.372)  [][]
 (-5.64 = -0.76 + -4.88)  0.16  .((......))(((.........)))..............  (sci:  0.617)  [][]
@@ -2106,7 +2106,7 @@ Sampling results:
 (-5.36 = -2.07 + -3.29)  0.10  ...(((....)))...........................  (sci:  0.590)  0.12  []
 (-3.62 =  1.67 + -5.29)  0.01  ((((.....))(((.........))).))...........  (sci:  0.400)  0.04  [[][]]
 
-                           51  cgcggcgcu__cgcgcaccg_gcg_____________ggc  90
+                           51  CGCGGCGCU__CGCGCACCG_GCG_____________GGC  90
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-1.61 =  0.66 + -2.26)  0.37  (((.........))).........................  (sci:  0.197)  []
 (-1.61 =  0.66 + -2.26)  0.37  (((.........))).........................  (sci:  0.197)  []
@@ -2214,7 +2214,7 @@ Sampling results:
 (-1.60 =  0.66 + -2.26)  0.37  (((.........))).........................  (sci:  0.200)  0.99  []
 ( 0.00 =  0.00 +  0.00)  0.03  ........................................  (sci: 0.000)  0.01  _
 
-                           61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                           61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.61 =  1.47 + -0.86)  0.22  ...(((.....)))..........................  (sci: -0.100)  []
 ( 0.61 =  1.47 + -0.86)  0.22  ...(((.....)))..........................  (sci: -0.100)  []
@@ -2322,7 +2322,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.58  ........................................  (sci: 0.000)  0.61  _
 ( 0.61 =  1.47 + -0.86)  0.22  ...(((.....)))..........................  (sci: -0.100)  0.39  []
 
-                           71  _gcg_____________ggcg_ucguccccgcgccugg__  110
+                           71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG__  110
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 2.60 =  3.34 + -0.75)  0.01  .......................(((....))).......  (sci: -0.447)  []
 ( 2.24 =  2.96 + -0.72)  0.02  .......................((......)).......  (sci: -0.385)  []
@@ -2430,7 +2430,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.72  ........................................  (sci: 0.000)  0.54  _
 ( 0.77 =  2.42 + -1.65)  0.21  .......................((....)).........  (sci: -0.130)  0.46  []
 
-                           81  _______ggcg_ucguccccgcgccugg____________  120
+                           81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  0.74  ........................................  (sci: -0.000)  _
 ( 0.00 =  0.00 +  0.00)  0.74  ........................................  (sci: -0.000)  _
@@ -2538,7 +2538,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.74  ........................................  (sci: 0.000)  0.75  _
 ( 0.77 =  2.42 + -1.65)  0.21  .............((....))...................  (sci: -0.140)  0.25  []
 
-                           91  g_ucguccccgcgccugg________________g_u___  130
+                           91  G_UCGUCCCCGCGCCUGG________________G_U___  130
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 2.24 =  2.96 + -0.72)  0.02  ...((......))...........................  (sci: -0.374)  []
 ( 0.00 =  0.00 +  0.00)  0.75  ........................................  (sci: -0.000)  _
@@ -2646,7 +2646,7 @@ Sampling results:
 ( 0.00 =  0.00 +  0.00)  0.75  ........................................  (sci: 0.000)  0.76  _
 ( 0.77 =  2.42 + -1.65)  0.21  ...((....)).............................  (sci: -0.130)  0.24  []
 
-                          101  gcgccugg________________g_u________cuggg  140
+                          101  GCGCCUGG________________G_U________CUGGG  140
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
@@ -2753,7 +2753,7 @@ Sampling results:
 
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: 0.000)  1.00  _
 
-                          111  ______________g_u________cuggg_____gcccg  150
+                          111  ______________G_U________CUGGG_____GCCCG  150
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
@@ -2860,7 +2860,7 @@ Sampling results:
 
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: 0.000)  1.00  _
 
-                          121  ____g_u________cuggg_____gcccgaggagaca__  160
+                          121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
@@ -2967,7 +2967,7 @@ Sampling results:
 
 ( 0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: 0.000)  1.00  _
 
-                          131  _____cuggg_____gcccgaggagaca__acgcg____  169
+                          131  _____CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( 0.00 =  0.00 +  0.00)  0.99  .......................................  (sci: -0.000)  _
 ( 0.00 =  0.00 +  0.00)  0.99  .......................................  (sci: -0.000)  _
@@ -3110,14 +3110,14 @@ Sampling results:
 (-10.17 = -10.41 +  0.24)  ......................................((((((..((...))...........((.....)).......................))))))...................................................................  0.1100000  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=10
-                               1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                               1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-24.90 = -12.20 + -12.70)  0.01  ....................((.........)).....((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  0.49  [][]
 (-25.84 = -13.91 + -11.93)  0.08  ......................................((((((.......((((((......(((.....)))...............)).))))))))))...................................................................  0.38  []
 (-23.61 = -10.01 + -13.60)  0.00  .............(((....((.........)).....((((((.......((((((......(((.....)))...............)).))))))))))...........................................))).....................  0.08  [[][]]
 (-22.37 = -10.47 + -11.90)  0.00  ..............(((.......)))...........((((((.......((((((....(((.......)))...............)).))))))))))...........................................((...............)).....  0.05  [][][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=20
-                             1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                             1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.00 =  0.00 +  0.00)  0.25  ........................................  (sci: -0.000)  _
 (  0.86 =  0.94 + -0.07)  0.06  ..............(((.......))).............  (sci: -0.051)  []
@@ -3135,7 +3135,7 @@ Sampling results:
 (  0.44 =  2.38 + -1.94)  0.12  ..............((....((.........)).....))  (sci: -0.030)  0.90  []
 (  0.00 =  0.00 +  0.00)  0.25  ........................................  (sci: 0.000)  0.10  _
 
-                            21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                            21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-10.41 = -5.91 + -4.50)  0.17  ...................((.(((...))).))......  (sci:  0.627)  []
 ( -9.31 = -4.79 + -4.52)  0.02  ((.........)).....((((.......)))).......  (sci:  0.561)  [][]
@@ -3153,7 +3153,7 @@ Sampling results:
 (-10.41 = -5.91 + -4.50)  0.17  ...................((.(((...))).))......  (sci:  0.630)  0.80  []
 ( -9.31 = -4.79 + -4.52)  0.02  ((.........)).....((((.......)))).......  (sci:  0.560)  0.20  [][]
 
-                            41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                            41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( -8.08 = -2.18 + -5.90)  0.12  ..(((...)))(((.........)))..............  (sci:  0.631)  [][]
 ( -8.09 = -3.12 + -4.96)  0.12  .((......))(((.........)))..............  (sci:  0.631)  [][]
@@ -3170,7 +3170,7 @@ Sampling results:
 
 ( -8.08 = -3.12 + -4.96)  0.12  .((......))(((.........)))..............  (sci:  0.630)  1.00  [][]
 
-                            61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                            61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 ( -0.48 =  0.46 + -0.94)  0.17  ...(((.....)))..........................  (sci:  0.053)  []
 ( -0.68 =  0.27 + -0.94)  0.24  ...(((.....)))..........................  (sci:  0.074)  []
@@ -3187,7 +3187,7 @@ Sampling results:
 
 ( -0.67 =  0.27 + -0.94)  0.24  ...(((.....)))..........................  (sci:  0.070)  1.00  []
 
-                            81  _______ggcg_ucguccccgcgccugg____________  120
+                            81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.67 =  1.50 + -0.83)  0.06  .............(((....))).................  (sci: -0.083)  []
 (  0.02 =  1.69 + -1.68)  0.20  .............((....))...................  (sci: -0.002)  []
@@ -3205,7 +3205,7 @@ Sampling results:
 ( -0.05 =  1.63 + -1.68)  0.22  .............((....))...................  (sci:  0.010)  0.60  []
 (  0.00 =  0.00 +  0.00)  0.20  ........................................  (sci: 0.000)  0.40  _
 
-                           101  gcgccugg________________g_u________cuggg  140
+                           101  GCGCCUGG________________G_U________CUGGG  140
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
 (  0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: -0.000)  _
@@ -3222,7 +3222,7 @@ Sampling results:
 
 (  0.00 =  0.00 +  0.00)  1.00  ........................................  (sci: 0.000)  1.00  _
 
-                           121  ____g_u________cuggg_____gcccgaggagaca__  160
+                           121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.00 =  0.00 +  0.00)  0.94  ........................................  (sci: -0.000)  _
 (  0.00 =  0.00 +  0.00)  0.94  ........................................  (sci: -0.000)  _
@@ -3240,7 +3240,7 @@ Sampling results:
 (  0.00 =  0.00 +  0.00)  0.94  ........................................  (sci: 0.000)  0.90  _
 (  1.95 =  2.35 + -0.40)  0.03  ..........................((...)).......  (sci: -0.200)  0.10  []
 
-                           141  _____gcccgaggagaca__acgcg____  169
+                           141  _____GCCCGAGGAGACA__ACGCG____  169
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (  0.00 =  0.00 +  0.00)  0.89  .............................  (sci: -0.000)  _
 (  0.00 =  0.00 +  0.00)  0.89  .............................  (sci: -0.000)  _
@@ -3366,7 +3366,7 @@ Sampling results:
 (-61.25 = -28.64 + -32.61)  0.12  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=2 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-36.98 = -30.64 + -6.34)  (((((((..((((.((...))...)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
 (-38.62 = -32.71 + -5.91)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  [[][][]]
@@ -3474,58 +3474,58 @@ Sampling results:
 (-38.62 = -32.71 + -5.91)  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-35.10 = -28.64 + -6.46)  0.7921208  (((((((..((((...........)))).(((((.......))))).....(((((.......)))))))))))).  (sci:  1.070)  1.0000000  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
-                     1  ___________gcggccgcgcgucggc_g_gggg_caagc  40
+                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGC  40
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                    11  _gcggccgcgcgucggc_g_gggg_caagcggggugguac  50
+                    11  _GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUAC  50
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  0.9900000  _
 ( 3.49 =  3.49 + 0.00)  .................................((...))  (sci: -0.220)  0.0100000  []
 
-                    21  cgucggc_g_gggg_caagcggggugguaccgcggcgcu_  60
+                    21  CGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU_  60
 (-1.80 = -1.88 + 0.08)  ......................((.....)).........  (sci:  0.120)  0.9900000  []
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  0.0100000  _
 
-                    31  gggg_caagcggggugguaccgcggcgcu__cgcgcaccg  70
+                    31  GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG  70
 (-1.80 = -1.88 + 0.08)  ............((.....))...................  (sci:  0.130)  0.9800000  []
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  0.0200000  _
 
-                    41  ggggugguaccgcggcgcu__cgcgcaccg_gcg______  80
+                    41  GGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG______  80
 (-1.80 = -1.88 + 0.08)  ..((.....)).............................  (sci:  0.160)  0.9500000  []
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  0.0500000  _
 
-                    51  cgcggcgcu__cgcgcaccg_gcg_____________ggc  90
+                    51  CGCGGCGCU__CGCGCACCG_GCG_____________GGC  90
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                    61  _cgcgcaccg_gcg_____________ggcg_ucgucccc  100
+                    61  _CGCGCACCG_GCG_____________GGCG_UCGUCCCC  100
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                    71  _gcg_____________ggcg_ucguccccgcgccugg__  110
+                    71  _GCG_____________GGCG_UCGUCCCCGCGCCUGG__  110
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                    81  _______ggcg_ucguccccgcgccugg____________  120
+                    81  _______GGCG_UCGUCCCCGCGCCUGG____________  120
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                    91  g_ucguccccgcgccugg________________g_u___  130
+                    91  G_UCGUCCCCGCGCCUGG________________G_U___  130
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                   101  gcgccugg________________g_u________cuggg  140
+                   101  GCGCCUGG________________G_U________CUGGG  140
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                   111  ______________g_u________cuggg_____gcccg  150
+                   111  ______________G_U________CUGGG_____GCCCG  150
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                   121  ____g_u________cuggg_____gcccgaggagaca__  160
+                   121  ____G_U________CUGGG_____GCCCGAGGAGACA__  160
 ( 0.00 =  0.00 + 0.00)  ........................................  (sci: 0.000)  1.0000000  _
 
-                   131  _____cuggg_____gcccgaggagaca__acgcg____  169
+                   131  _____CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 ( 0.00 =  0.00 + 0.00)  .......................................  (sci: 0.000)  1.0000000  _
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
-                       1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-11.26 = -11.32 + 0.06)  .......(((.((((.....)))).)))........................  (sci:  0.520)  1.0000000  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1 --consensus=mis --nfactor=1 --numSamples=10 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
@@ -3533,7 +3533,7 @@ Sampling results:
 (-34.66 = -24.48 + -10.18)  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  1.0000000  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.0001 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=20
-                               1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                               1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-33.50 = -22.26 + -11.24)  0.71  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.90  [[][][]]
 (-31.63 = -21.56 + -10.07)  0.03  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.10  [[][]]
 
@@ -3861,12 +3861,12 @@ Sampling results:
 (  5.16 =  4.99 +   0.17)  ........(......)  0.01  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=10
-                               1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                               1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-33.50 = -22.26 + -11.24)  0.71  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  0.90  [[][][]]
 (-31.63 = -21.56 + -10.07)  0.03  (((((((......................(((((.......))))).....(((((.......)))))))))))).  0.10  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1.1 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=0 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
-                            1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                            1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
 (-7.03 = -6.61 + -0.42)  0.01  .......((..((((.....))))..)).........(....).........  [][]
 (-4.88 = -3.84 + -1.04)  0.00  ....((.((..((((.....))))(...........).......)).))...  [[][]]
@@ -3976,21 +3976,21 @@ Sampling results:
 (-7.59 = -7.25 + -0.34)  0.03  .......((..((((.....))))..)).........(......).......  0.11  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=10 --outputLowProbFilter=0.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=10
-                      1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                      1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-2.83 = -2.65 + -0.18)  .......................................((.((.....))((((.....................................))))...))....................................................................  (sci:  0.040)  0.60  [[][]]
 (-2.66 = -2.93 +  0.27)  ..........................................((.....))((((.....................................)))).........................................................................  (sci:  0.040)  0.40  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln --cfactor=1.1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=1 --sci=0 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
-                                   1  gcgugcguagcucagc__ggu__agagcaccaggcuuuca  40
+                                   1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCA  40
 (-11.62 = -5.52 +  -6.10)  0.6555246  .........((((...........))))............  0.9900000  []
 ( -5.44 =  0.57 +  -6.01)  0.0000143  .....((..((((...........))))..))..(....)  0.0100000  [][]
 
-                                  21  u__agagcaccaggcuuucacccagaaagucacggguucg  60
+                                  21  U__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCG  60
 (-15.85 = -7.97 +  -7.88)  0.5316954  .........(((((.......)))))..............  0.8900000  []
 (-14.16 = -5.01 +  -9.15)  0.0282897  .........(((((.......)))))....(........)  0.1000000  [][]
 (-11.14 =  0.11 + -11.25)  0.0001517  .......(.(((((.......)))))...((...))...)  0.0100000  [[][]]
 
-                                  41  cccagaaagucacggguucgaaucccaucgaacgcg  76
+                                  41  CCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-17.45 = -8.56 +  -8.89)  0.9730040  ...........(((((.......)))))........  0.9900000  []
 (-14.15 = -4.54 +  -9.61)  0.0031476  ....(.....)(((((.......)))))........  0.0100000  [][]
 
@@ -4111,7 +4111,7 @@ Sampling results:
 ( 0.05 =  0.47 + -0.42)  .......................................((.(((...))).(((.....................................)))....))....................................................................  (sci: 0.000)  0.10  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=0.9 --consensus=consensus --nfactor=0.9 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
-                         1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                         1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-30.24 = -14.58 + -15.66)  .............(((.((.((.........))).)..((((((.(....)(((((.....(((((.....))))............)...)))))))))))...........................................))).....................  (sci:  0.370)  0.18  [[][[][]]]
 (-27.97 = -13.04 + -14.93)  ..............(((.......))).....((.(..((((((.(....)(((((..(..(((((.....))))............))..)))))))))))..(..................................).....))).....................  (sci:  0.340)  0.13  [][[[][]][]]
 (-26.69 = -11.16 + -15.53)  .................(((............((.(..((((((.(....).((((..(..(((((.....))))............))..)))).))))))..................(..........).............)))...(....)....))).....  (sci:  0.330)  0.12  [[[[][]][]][]]
@@ -4189,26 +4189,26 @@ Sampling results:
 (-31.70 = -29.92 + -1.78)  0.80  (((((((..(((.............))).(((((.......))))).....(((((.......)))))))))))).  (sci:  0.910)  1.00  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln --cfactor=1.1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --probDecimals=7 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=20
-                                 1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                                 1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (-0.97 = -1.05 +  0.08)  0.2036722  .........................................((......))......................................................................................................................  (sci:  0.020)  0.8500000  []
 ( 0.64 =  0.56 +  0.08)  0.0142876  .........................................((......)).(((.....................................)))..........................................................................  (sci: -0.010)  0.0700000  [][]
 ( 0.00 =  0.00 +  0.00)  0.0535689  .........................................................................................................................................................................  (sci: 0.000)  0.0600000  _
 ( 3.51 =  3.65 + -0.14)  0.0001194  .......................................((.(((...)))(((((..................................).))))...))....................................................................  (sci: -0.060)  0.0200000  [[][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=40 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1.1 --numSamples=100 --outputLowProbFilter=0.0001 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=1 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
-                        1  uggugguggcccgcucaaccggcggccca______cugau  40
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAU  40
 (-14.29 = -12.33 + -1.96)  .......(((((((.......)))))))............  (sci:  0.700)  1.00  []
 
-                       21  ggcggccca______cugauugcgccuuuuug  52
+                       21  GGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 ( -1.33 =   0.73 + -2.06)  .(((..(..........)..))).........  (sci:  0.180)  0.98  []
 (  3.11 =   4.36 + -1.25)  .((((.(..........).)))).(......)  (sci: -0.430)  0.02  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=100 /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln --cfactor=1 --consensus=consensus --nfactor=1 --numSamples=100 --outputLowProbFilter=0.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --probDecimals=2 --ribosumscoring=0 --sci=1 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
-                      1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                      1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-9.15 = -9.21 +  0.06)  .......(((.((((.....)))).)))........................  (sci:  0.530)  0.99  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
-                     1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                     1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-4.89 = -5.31 + 0.42)  .((....(((.((((.....)))).))).......))...............  (sci:  0.300)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=37
@@ -4216,7 +4216,7 @@ Sampling results:
 (22.13 = 9.88 + 12.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-20.74 = -11.54 + -9.20)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.020)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
@@ -4224,7 +4224,7 @@ Sampling results:
 (-9.81 = -10.33 + 0.52)  .((....(((.((((.....)))).))).......))...............  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
-                   1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                   1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (6.06 = 2.55 + 3.51)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
@@ -4240,7 +4240,7 @@ Sampling results:
 (12.29 = 8.23 + 4.06)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.210)  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-23.27 = -11.47 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 (-22.85 = -11.05 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
 (-22.24 = -10.44 + -11.80)  .((....(((.((((.....)))).))).......))...............  []
@@ -4378,7 +4378,7 @@ Sampling results:
 (-28.96 = -18.74 + -10.22)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.880)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
-                        1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-21.42 = -9.37 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 (-21.10 = -9.05 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
 (-20.54 = -8.49 + -12.05)  .((....(((.((((.....)))).))).......))...............  []
@@ -4392,15 +4392,15 @@ Sampling results:
 (25.30 = 7.05 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1.1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-32.45 = -24.15 + -8.30)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37
-                    1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (13.28 = 9.21 + 4.07)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.240)  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=0.9 --consensus=consensus --nfactor=1.1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=17
-                       1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                       1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-10.93 = -11.05 + 0.12)  .((....(((.((((.....)))).))).......))...............  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=mis --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=25.9
@@ -4408,7 +4408,7 @@ Sampling results:
 (10.63 = 8.12 + 2.51)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=25.9
-                        1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                        1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-18.75 = -8.02 + -10.73)  .((....(((.((((.....)))).))).......))...............  (sci:  0.910)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-200 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
@@ -4416,7 +4416,7 @@ Sampling results:
 (-38.58 = -11.54 + -27.04)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.860)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/trp_attenuator.aln '.((....(((.((((.....)))).))).......))...............' --cfactor=1.1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
-                         1  uggugguggcccgcucaaccggcggccca______cugauugcgccuuuuug  52
+                         1  UGGUGGUGGCCCGCUCAACCGGCGGCCCA______CUGAUUGCGCCUUUUUG  52
 (-22.16 = -10.23 + -11.93)  .((....(((.((((.....)))).))).......))...............  (sci:  0.930)  []
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=0.9 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=17
@@ -4428,7 +4428,7 @@ Sampling results:
 (-47.76 = -17.67 + -30.09)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
-                     1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                     1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (25.40 = 7.15 + 18.25)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
@@ -4578,7 +4578,7 @@ Sampling results:
 (-31.00 = -20.74 + -10.26)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1 --consensus=consensus --nfactor=0.9 --pairingFraction=-150 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=1 --sci=1 --shapeLevel=5 --temperature=37
-                    1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                    1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (12.67 = 9.21 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.220)  [][]
 (12.75 = 9.29 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.220)  [][]
 (13.27 = 9.81 + 3.46)  .........................................(((...)))((((.....................................))))..........................................................................  (sci: -0.230)  [][]
@@ -4716,7 +4716,7 @@ Sampling results:
 (-48.75 = -18.74 + -30.01)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  1.480)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/t-box.aln '.........................................(((...)))((((.....................................))))..........................................................................' --cfactor=1.1 --consensus=consensus --nfactor=1.1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner2004.par --ribosumscoring=1 --sci=0 --shapeLevel=5 --temperature=17
-                   1  ___________gcggccgcgcgucggc_g_gggg_caagcggggugguaccgcggcgcu__cgcgcaccg_gcg_____________ggcg_ucguccccgcgccugg________________g_u________cuggg_____gcccgaggagaca__acgcg____  169
+                   1  ___________GCGGCCGCGCGUCGGC_G_GGGG_CAAGCGGGGUGGUACCGCGGCGCU__CGCGCACCG_GCG_____________GGCG_UCGUCCCCGCGCCUGG________________G_U________CUGGG_____GCCCGAGGAGACA__ACGCG____  169
 (8.66 = 3.13 + 5.53)  .........................................(((...)))((((.....................................))))..........................................................................  [][]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=17
@@ -4724,7 +4724,7 @@ Sampling results:
 (-31.86 = -29.90 + -1.96)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  (sci:  0.810)  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=0.9 --consensus=consensus --nfactor=0.9 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=0 --shapeLevel=5 --temperature=25.9
-                        1  gcgugcguagcucagc__ggu__agagcaccaggcuuucacccagaaagucacggguucgaaucccaucgaacgcg  76
+                        1  GCGUGCGUAGCUCAGC__GGU__AGAGCACCAGGCUUUCACCCAGAAAGUCACGGGUUCGAAUCCCAUCGAACGCG  76
 (-25.91 = -24.15 + -1.76)  (((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).  [[][][]]
 
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAalishapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate /vol/fold-grammars/src/Misc/Test-Suite/StefanStyle/tRNA_example_ungap.aln '(((((((..(((..((...))....)))..((((.......))))......(((((.......)))))))))))).' --cfactor=1 --consensus=mis --nfactor=1 --pairingFraction=-300 --param=/vol/gapc/share/gapc/librna/rna_turner1999.par --ribosumscoring=0 --sci=1 --shapeLevel=5 --temperature=37

--- a/Misc/Test-Suite/StefanStyle/Truth/rnashapes.run.out
+++ b/Misc/Test-Suite/StefanStyle/Truth/rnashapes.run.out
@@ -1,14 +1,14 @@
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -17.20  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -28.23  0.5887811  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -17.85  ..(((((....))))).........(((((.....)))))  [][]
@@ -16,22 +16,22 @@
     11  UCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -12.99  (((...)))..(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -30.43  0.5841493  ((((((((((((......))))))))..)))).((((........)))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.56  0.6245146  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.07  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -14.50  ..(((((....))))).........(((((.....)))))  [][]
@@ -39,22 +39,22 @@
     21  UCGUAGCAGUUGACUACUGUUAUGU  45
 -10.00  .(((((((((.....))))))))).  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -37.73  0.4901720  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.50  0.0930384  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -20.72  ..(((((((((((................)))))))))))  []
@@ -62,22 +62,22 @@
     31  GUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -15.26  ((((.((.((((......))))..))...))))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.10  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -31.50  0.2325546  ((((((((((((......))))))))..)))).((((........)))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.56  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -16.88  0.5148318  ..(((((....))))).........(((((.....)))))  [][]
@@ -85,22 +85,22 @@
                11  UCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -12.78  0.5727331  (((...)))..(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=0 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -32.10  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -21.80  ((((((((((((......))))))))..)))).((((........)))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -25.55  0.3569105  ((((((((((((......))))))))..))))........  []
@@ -108,22 +108,22 @@
                21  CGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -12.08  0.3868565  .(((((((((....))))).....))))..  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -25.79  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -32.74  0.4767591  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -19.58  0.4131966  ..(((((((((((...(......).....)))))))))))  []
@@ -131,22 +131,22 @@
                31  GUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -12.24  0.1519109  ((((.((.((((......))))..))...))))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -29.67  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -35.09  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -35.09  0.0550879  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -18.10  0.2314912  ..(((((((((((...(......).....)))))))))))  []
@@ -154,22 +154,22 @@
                31  GUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -12.20  0.0646347  .(((.......))).....(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.49  0.0464943  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -31.50  ((((((((((((......))))))))..)))).((((........)))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -29.83  0.1967416  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -13.80  ..(((((....))))).........(((((.....)))))  [][]
@@ -177,23 +177,23 @@
     11  UCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -10.00  ...........(((((((((.....))))))))).  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=mfe --allowLP=1 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -22.70  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -35.96  0.4802911  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 -35.50  0.2162815  .((((((((((((................)))))))))))).....((.(((((((...))))))).))  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -21.10  0.8624634  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -19.70  ((((((((((((......))))))))..))))........  []
@@ -203,23 +203,23 @@
  -2.10  ...((((........)))).  []
  -1.60  (((((...)).)))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.59  ((((((((((((......))))))))..)))).((((........)))).  [][]
 -26.09  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.50  0.5332375  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -33.91  0.5573167  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -27.59  (((.((.((((....)))).)))))(((((....))))).  [][]
@@ -230,17 +230,17 @@
 -11.28  .((((.....(((........)))))))..  []
 -10.78  .(((.....((((((...)).)))))))..  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -26.59  0.8651874  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -34.35  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -22.70  0.0424749  ((((((((((((......)))))))....((((........)))))))))  [[][]]
@@ -253,7 +253,7 @@
 -21.70  0.0083845  ((((((((((((......)))))))....((((((...)).)))))))))  [[][]]
 -21.70  0.0083845  .(((((((((((......)))))))....((((........)))))))).  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -20.72  0.3670086  ..(((((((((((................)))))))))))  []
@@ -270,14 +270,14 @@
 -12.82  0.0977549  .........((((((.....))))))...  []
 -12.68  0.0766806  ......((.(((((((...))))))))).  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.50  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 -27.60  .((((((((((((................)))))))))))).........((((((...))))))....  [][]
 -27.50  .(((((((((....((((..........)))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -34.76  0.3072038  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
@@ -285,7 +285,7 @@
 -33.84  0.0653249  .(((((((((....((((..........)))))))))))))........(((((((...)))))))...  [][]
 -33.78  0.0458784  .((((((((((((................)))))))))))).....((.(((((((...))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -27.58  ((((((((((((......))))))))..)))).((((........)))).  [][]
@@ -295,7 +295,7 @@
 -26.86  ((((((((((((......))))))))..))))..(((........)))..  [][]
 -26.79  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -19.70  ((((((((((((......))))))))..))))........  []
@@ -306,18 +306,18 @@
 -10.60  ....(((....))).((..((((........)))).))..  [][]
  -9.90  .((((.....)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=0 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.56  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.32  ..(((((....))))).....(((((((((.....))))))))).  [][]
 -23.46  ..(((((....)))))...(.(((((((((.....))))))))))  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -37.63  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
@@ -327,7 +327,7 @@
 -36.78  .((((((((((((...(......).....)))))))))))).....((.((((((.....)))))).))  [][]
 -36.64  .((((((((((((...(......).....)))))))))))).....((.(((((((...))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -14.19  0.4249365  ..(((((((((((................)))))))))))  []
@@ -341,12 +341,12 @@
  -7.50  0.0804267  ................((.(((((((...))))))).))  []
  -7.30  0.0581394  ................((.((((((.....)))))).))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=nodangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.15  0.9159949  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -40.59  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
@@ -356,13 +356,13 @@
 -39.87  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 -39.72  .((((((((((((...(......).....)))))))))))).....((.((((((.....)))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -32.74  0.4767591  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 -31.99  0.1349554  ((((((((((((......)))))))....((((((...)).)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -17.47  0.6674704  ..(((((....))))).........(((((.....)))))  [][]
@@ -371,7 +371,7 @@
  -2.23  0.7981432  ((((....))))...  []
  -1.25  0.1534212  .(((....)))....  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=overdangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
@@ -382,12 +382,12 @@
 -27.57  .(((((((((((..................)))))))))))........((((((.....))))))...  [][]
 -27.50  .(((((((((....((((..........)))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  0.1717764  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.10  (((((.((((((......)))))).....((((........)))))))))  [[][]]
@@ -396,7 +396,7 @@
 -23.30  (((((.((((((......)))))).((((......))))......)))))  [[][]]
 -23.20  (((((.((((((......))))))......(((........))).)))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -26.58  0.1726188  ((((((((((((......))))))))..))))........  []
@@ -414,7 +414,7 @@
 -10.84  0.0278460  .(((.....((((((...)).)))))))..  []
 -10.80  0.0259797  (.((((((((....)))))..))).)....  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -29.83  0.0690669  (((((.((((((......)))))).....((((........)))))))))  [[][]]
@@ -425,12 +425,12 @@
 -29.01  0.0173781  (((((..(((((....))))).((((((((....)))))..))).)))))  [[][]]
 -28.85  0.0132762  (((((.((((((......)))))).((((......))))......)))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  0.7357260  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -31.50  ((((((((((((......))))))))..)))).((((........)))).  [][]
@@ -441,7 +441,7 @@
 -30.54  ((((((((((((......))))))))..)))).((((.(....).)))).  [][]
 -30.51  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -19.70  ((((((((((((......))))))))..))))........  []
@@ -453,25 +453,25 @@
 -10.60  ....(((....))).((..((((........)))).))..  [][]
  -9.90  .((((.....)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=subopt --allowLP=1 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -33.91  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 -33.66  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  [][]
 -33.22  .((((((((((((.(.(......).)...))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.59  0.5130506  ((((((((((((......))))))))..)))).((((........)))).  [][]
 -26.09  0.2211839  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -31.92  0.2243121  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -17.85  0.7397266  ..(((((....))))).........(((((.....)))))  [][]
@@ -479,23 +479,23 @@
                31  UGACUACUGUUAUGU  45
  -2.94  0.9030473  ((((....))))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.59  ((((((((((((......))))))))..)))).((((........)))).  [][]
 -26.09  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.50  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -26.59  0.8651874  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -27.59  0.6718787  (((.((.((((....)))).)))))(((((....))))).  [][]
@@ -503,22 +503,22 @@
                21  CGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -11.68  0.3476695  .(((.....((((........)))))))..  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -29.67  0.5187406  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.10  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  0.3551196  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -26.58  0.2919106  ((((((((((((......))))))))..))))........  []
@@ -527,22 +527,22 @@
                31  CCCAGCUACUCGGGAGGCUC  50
  -6.88  0.7476337  (((........)))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -34.50  0.0623852  (((((..(((((....))))).((.(((((....)))))..))..)))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -19.56  ..(((((....)))))..(((((.......))))).....  [][]
@@ -550,22 +550,22 @@
     31  UGACUACUGUUAUGU  45
  -3.64  ((((....))))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=0 --grammar=macrostate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.56  0.6044912  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -21.03  0.8927880  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.15  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -25.55  0.3569105  ((((((((((((......))))))))..))))........  []
@@ -574,22 +574,22 @@
                11  CGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -16.50  0.1854838  ....(((.(...((((((((....)))))..))).)))).  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=nodangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -32.73  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  0.7825119  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.20  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -23.77  ((((((((((((......))))))))..).))).......  []
@@ -599,22 +599,22 @@
 -15.06  .((((.....)))).((..((((........)))).))..  [][]
 -14.55  .((((((....))).....((((........)))).))).  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  0.9073730  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.10  0.0699536  (((((.((((((......)))))).....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.50  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -19.70  ((((((((((((......))))))))..))))........  []
@@ -622,23 +622,23 @@
     31  CCCAGCUACUCGGGAGGCUC  50
  -3.60  (((........)))......  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  0.1350871  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -27.58  0.1661670  ((((((((((((......))))))))..)))).((((........)))).  [][]
 -27.41  0.1248265  ((((((((((((......)))))))....((((........)))))))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.20  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -17.65  0.4178766  ..(((((((((((................)))))))))))  []
@@ -650,24 +650,24 @@
                41  GGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -11.31  0.6143380  .........(((((((...)))))))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=shapes --allowLP=1 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --absoluteDeviation=1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -34.49  0.1416814  (((((..(((((....))))).((.(((((....)))))..))..)))))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
            1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.59  0.51  ((((((((((((......))))))))..)))).((((........)))).  0.67  [][]
 -26.09  0.22  ((((((((((((......)))))))....((((........)))))))))  0.33  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
            1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -26.59  0.51  ((((((((((((......))))))))..)))).((((........)))).  0.67  [][]
 -26.09  0.22  ((((((((((((......)))))))....((((........)))))))))  0.33  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -15.00  0.7799394  ..(((((....))))).........(((((.....)))))  0.9889201  [][]
@@ -675,22 +675,22 @@
                21  UCGUAGCAGUUGACUACUGUUAUGU  45
 -10.86  0.9509556  .(((((((((.....))))))))).  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -25.79  0.21  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.56  .((((((((((((................))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.49  0.26  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -19.40  ..(((((((((((................)))))))))))  1.00  []
@@ -708,24 +708,24 @@
 -12.24  ((((.((.((((......))))..))...))))......  0.52  []
 -12.05  .(((.......))).....(((((((...)))))))...  0.48  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.07  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 -11.47  (((((((....)))))..(((((.......)))))....))....  0.00  [[][]]
 -10.29  (((((((....)))))((...))...((((.....))))))....  0.00  [[][][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -18.80  0.14  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  0.18  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -23.69  ((((((((((((......))))))))..))))........  0.73  []
@@ -734,23 +734,23 @@
     31  CCCAGCUACUCGGGAGGCUC  50
  -5.73  (((........)))......  1.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  0.1790878  ..(((((....))))).....(((((((((.....))))))))).  0.9999999  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
 >unnamed sequence
            1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.10  0.27  (((((.((((((......)))))).....((((........)))))))))  0.98  [[][]]
 -21.80  0.01  ((((((((((((......))))))))..)))).((((........)))).  0.02  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -39.87  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -13.20  ..(((((....)))))..(((((.......))))).....  1.0000000  [][]
@@ -759,24 +759,24 @@
  -1.00  ((((....))))...  0.8754768  []
   0.00  ...............  0.1245232  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=0 --grammar=macrostate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -31.24  0.1481447  ((((((((((((......)))))))....((((........)))))))))  0.5708332  [[][]]
 -31.50  0.2325546  ((((((((((((......))))))))..)))).((((........)))).  0.4291668  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -17.10  ..(((((....))))).....(((((((((.....))))))))).  0.9997850  [][]
 -11.50  .((((((....))))).....(((((((((.....))))))))))  0.0002150  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -26.10  .((((((((((((................))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -17.93  ..(((((((((((...(......).....)))))))))))  1.0000000  []
@@ -787,24 +787,24 @@
     41  GGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -10.51  .........(((((((...)))))))...  0.9870418  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -36.03  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -38.63  0.22  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  0.88  [][]
 -37.62  0.04  .((((((((((((...(......).....))))))))))))(......)(((((((...)))))))...  0.12  [][][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.20  .((((((((((((................))))))))))))........(((((((...)))))))...  0.98  [][]
 -25.90  .((((((((((((................))))))))))))(......)(((((((...)))))))...  0.02  [][][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -14.50  ..(((((....))))).........(((((.....)))))  0.97  [][]
@@ -814,22 +814,22 @@
 -10.10  (((...)))..(((((((((.....))))))))).  0.59  [][]
 -10.00  ...........(((((((((.....))))))))).  0.41  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=overdangle --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -32.74  ((((((((((((......)))))))....((((........)))))))))  1.0000000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  0.35  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.50  0.0605386  .((((((((((((................))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 -19.41  0.19  ..(((((....))))).........(((((.....)))))  0.97  [][]
@@ -840,22 +840,22 @@
 -15.36  0.32  (((...)))..(((((((((.....))))))))).  0.91  [][]
 -14.21  0.04  ...........(((((((((.....))))))))).  0.09  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=microstate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  0.2718577  ..(((((....))))).....(((((((((.....))))))))).  0.9999986  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.07  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --lowProbFilter=0.01 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --structureProbs=1 --temperature=37 --windowIncrement=20
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -14.49  0.4101692  ..(((((((((((................)))))))))))  1.0000000  []
@@ -869,23 +869,23 @@
  -9.20  0.4025523  .........(((((((...)))))))...  0.9882261  []
  -6.10  0.0026326  ((.....))(((((((...)))))))...  0.0117739  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probs --allowLP=1 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --lowProbFilter=0.01 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -22.60  ((((((((((((......)))))))....((((........)))))))))  0.91  [[][]]
 -20.90  ((((((((((((......))))))))..)))).((((........)))).  0.09  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.32  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -19.70  ((((((((((((......))))))))..))))........  1.00  []
@@ -894,7 +894,7 @@
  -7.70  ....((.((...((.(((((....)))))..))...))))  0.70  []
  -8.60  .((((.....)))).((..((((........)))).))..  0.30  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=nodangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -913,7 +913,7 @@ Sampling results:
 
 -17.20  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1022,7 +1022,7 @@ Sampling results:
 
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1041,7 +1041,7 @@ Sampling results:
 
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1258,22 +1258,22 @@ Sampling results:
  -9.30  0.34  ...................(((((((...)))))))...  0.53  []
  -8.80  0.15  .(((.......))).....(((((((...)))))))...  0.47  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=overdangle --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  0.92  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=17 --windowIncrement=20
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -34.50  0.0623852  (((((..(((((....))))).((.(((((....)))))..))..)))))  1.0000000  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.07  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=10
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1491,7 +1491,7 @@ Sampling results:
 -12.30  0.1538475  (((...)))..(((((((((.....))))))))).  0.7200000  [][]
 -11.87  0.0746177  ...........(((((((((.....))))))))).  0.2800000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=microstate --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1510,17 +1510,17 @@ Sampling results:
 
 -40.22  0.12  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -26.59  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -28.20  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=40 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=37 --windowIncrement=30
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGG  40
 -14.49  ..(((((((((((................)))))))))))  1.0000000  []
@@ -1529,7 +1529,7 @@ Sampling results:
  -9.20  ...................(((((((...)))))))...  0.7400000  []
  -8.70  .(((.......))).....(((((((...)))))))...  0.2600000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=0 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=30
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1548,13 +1548,13 @@ Sampling results:
 
 -24.07  0.95  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=10
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -30.43  ((((((((((((......))))))))..)))).((((........)))).  0.83  [][]
 -29.82  ((((((((((((......)))))))....((((........)))))))))  0.17  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1573,7 +1573,7 @@ Sampling results:
 
 -24.15  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=10
 >unnamed sequence
                 1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1791,7 +1791,7 @@ Sampling results:
 -14.93  0.2260089  ....(((.(.(.(..(((((....)))))..).).)))).  0.9600000  []
 -13.63  0.0237098  .((((.....)))).((..((((........)))).))..  0.0400000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=nodangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -1900,7 +1900,7 @@ Sampling results:
 
 -25.79  0.1355329  .((((((((((((................))))))))))))........(((((((...)))))))...  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=37 --windowIncrement=10
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2009,7 +2009,7 @@ Sampling results:
 
 -28.49  .((((((((((((................))))))))))))........(((((((...)))))))...  0.9900000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=17 --windowIncrement=30
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2118,7 +2118,7 @@ Sampling results:
 
 -26.59  0.8021630  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -27.69  (((.((.((((....)))).)))))(((((....))))).  0.6800000  [][]
@@ -2127,7 +2127,7 @@ Sampling results:
     31  CCCAGCUACUCGGGAGGCUC  50
  -6.37  (((........)))......  1.0000000  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=overdangle --windowSize=100 ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=10 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
            1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2146,7 +2146,7 @@ Sampling results:
 
 -28.20  0.28  .((((((((((((................))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2255,7 +2255,7 @@ Sampling results:
 
 -40.94  .((((((((((((...(......).....))))))))))))........(((((((...)))))))...  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=20
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2274,7 +2274,7 @@ Sampling results:
 
 -19.90  0.27  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=40 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=37 --windowIncrement=30
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGU  40
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2491,7 +2491,7 @@ Sampling results:
  -1.00  0.41  ((((....))))...  0.95  []
   0.00  0.08  ...............  0.05  _
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=microstate --windowSize=100 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=10 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
            1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 10 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2511,7 +2511,7 @@ Sampling results:
 -27.58  0.06  ((((((((((((......))))))))..)))).((((........)))).  0.60  [][]
 -27.48  0.05  ((((((((((((......))))))))...((((........)))).))))  0.40  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=2 --shapeLevel=5 --showSamples=1 --structureProbs=0 --temperature=17 --windowIncrement=30
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 100 samples, drawn by stochastic backtrace to estimate shape frequencies:
@@ -2620,12 +2620,12 @@ Sampling results:
 
 -26.59  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.0001 --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=10 --outputLowProbFilter=0.0001 --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --probDecimals=7 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=25.9 --windowIncrement=20
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  0.7848935  ..(((((....))))).....(((((((((.....))))))))).  1.0000000  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=20
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=40 gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --numSamples=100 --outputLowProbFilter=0 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=0 --temperature=17 --windowIncrement=20
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACU  40
 -26.58  ((((((((((((......))))))))..))))........  0.63  []
@@ -2634,12 +2634,12 @@ Sampling results:
     21  CGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -11.68  .(((.....((((........)))))))..  1.00  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.1 --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=10
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=sample --allowLP=1 --grammar=macrostate --windowSize=100 AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --numSamples=100 --outputLowProbFilter=0.1 --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --probDecimals=2 --shapeLevel=5 --showSamples=0 --structureProbs=1 --temperature=37 --windowIncrement=10
 >unnamed sequence
            1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  0.90  ..(((((....))))).....(((((((((.....))))))))).  1.00  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37
 1)  Shape: [][]  Score: -63.79  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2652,7 +2652,7 @@ Sampling results:
 -20.90  0.0347803  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -91.54  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2665,7 +2665,7 @@ Sampling results:
 -30.31  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -91.54  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2678,7 +2678,7 @@ Sampling results:
 -30.31  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -91.54  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2691,7 +2691,7 @@ Sampling results:
 -30.31  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -97.28  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2704,10 +2704,10 @@ Sampling results:
 -31.24  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
 1)  Shape: [][]  Score: -71.00  Ratio of MFE: 0.98
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2720,7 +2720,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.90  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37
 1)  Shape: [][]  Score: -71.00  Ratio of MFE: 0.98
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2733,7 +2733,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.90  0.0244402  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=17
 1)  Shape: [][]  Score: -98.10  Ratio of MFE: 1.00
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2746,7 +2746,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -31.50  0.0977747  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
 1)  Shape: [][]  Score: -86.00  Ratio of MFE: 1.00
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2759,7 +2759,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.58  0.0745459  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
 1)  Shape: [][]  Score: -71.10  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2772,7 +2772,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.70  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=37
 1)  Shape: [][]  Score: -71.10  Ratio of MFE: 1.00
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2785,7 +2785,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.70  0.0424749  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -97.54  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2798,7 +2798,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -31.50  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -85.02  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2811,7 +2811,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.15  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
 1)  Shape: [][]  Score: -85.02  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2824,7 +2824,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.15  0.0024201  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast --allowLP=0 --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
 1)  Shape: [][]  Score: -97.91  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2837,7 +2837,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -31.45  0.0008031  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
 1)  Shape: [][]  Score: -91.54  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2850,7 +2850,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -30.31  0.0082296  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
 1)  Shape: [][]  Score: -79.16  Ratio of MFE: 1.00
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2863,7 +2863,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -26.59  0.5130506  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -79.14  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2876,7 +2876,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -26.12  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=nodangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -79.14  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2889,10 +2889,10 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -26.12  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
 1)  Shape: [][]  Score: -71.00  Ratio of MFE: 0.98
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2905,13 +2905,13 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.90  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=17
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=overdangle castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=17
 No consensus shapes found. Try to increase energy range with --absoluteDeviation or --relativeDeviation.
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -85.17  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2924,7 +2924,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.15  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=37
 1)  Shape: [][]  Score: -69.09  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2937,7 +2937,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -21.80  0.0018698  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=17
 1)  Shape: [][]  Score: -98.10  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2950,7 +2950,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -31.50  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=microstate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=37
 1)  Shape: [][]  Score: -71.10  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2963,7 +2963,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.70  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -85.56  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2976,7 +2976,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.58  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=1 --temperature=25.9
 1)  Shape: [][]  Score: -85.02  Ratio of MFE: 0.97
 >seq1
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -2989,7 +2989,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.15  0.0024201  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --structureProbs=0 --temperature=37
 1)  Shape: [][]  Score: -69.09  Ratio of MFE: 0.97
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -3002,7 +3002,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -21.80  ((((((((((((......))))))))..)))).((((........)))).  R: 2  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=cast  --grammar=macrostate castInput.mfa --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --structureProbs=0 --temperature=25.9
 1)  Shape: [][]  Score: -85.56  Ratio of MFE: 1.00
 >seq1
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
@@ -3015,47 +3015,47 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -27.58  ((((((((((((......))))))))..)))).((((........)))).  R: 1  [][]
 
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -31.92  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.38  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -35.96  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -17.20  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -27.48  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -19.90  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -34.76  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -25.23  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3075,7 +3075,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -22.34  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -22.18  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -20.70  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3095,7 +3095,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -18.20  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -18.00  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -26.59  ..(((((....))))).....(((((((((.....))))))))).  [][]
@@ -3115,7 +3115,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -24.50  ..(((((....))))).....(((((((((.....))))))))).  [][]
 -24.32  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -27.60  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3135,67 +3135,67 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -24.60  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -24.38  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -28.91  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -28.91  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=0 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -23.67  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -36.91  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -24.38  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -17.10  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -20.90  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -18.80  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -26.59  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -25.23  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -20.70  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -28.91  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3215,7 +3215,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -25.69  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -25.56  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=17
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -28.91  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3235,7 +3235,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -25.69  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -25.56  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -23.67  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3255,7 +3255,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -21.06  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -20.90  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -18.80  .((.((.((((....)))).)))).....((((........)))).....  [][]
@@ -3275,22 +3275,22 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 -16.60  .((.((.((((....)))).)))).....((((........)))).....  [][]
 -16.60  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC '.((.((.((((....)))).)))).....((((........)))).....' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=37
 >unnamed sequence
      1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC  50
 -18.80  .((.((.((((....)))).)))).....((((........)))).....  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA '.((((((((((((................))))))))))))........(((((((...)))))))...' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA  69
 -34.76  .((((((((((((................))))))))))))........(((((((...)))))))...  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -24.07  ..(((((....))))).....(((((((((.....))))))))).  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=eval --allowLP=1 --grammar=macrostate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU '..(((((....))))).....(((((((((.....))))))))).' --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --shapeLevel=5 --temperature=25.9
 >unnamed sequence
      1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU  45
 -23.11  ..(((((....))))).....(((((((((.....))))))))).  [][]
@@ -3391,7 +3391,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 #CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=abstract --allowLP=1 --grammar=macrostate '..(((((....))))).....(((((((((.....))))))))).' --shapeLevel=5
 [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=37
 1 43 0.326597 ubox
 2 40 0.00299267 ubox
 2 41 0.940309 ubox
@@ -3464,7 +3464,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.986008 ubox
 56 60 0.912411 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=37
 1 43 0.326597 ubox
 2 41 0.940309 ubox
 2 42 0.334022 ubox
@@ -3493,7 +3493,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.986008 ubox
 56 60 0.912411 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=17
 1 43 0.552585 ubox
 2 41 0.83066 ubox
 2 42 0.556108 ubox
@@ -3526,7 +3526,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.986447 ubox
 56 60 0.8361 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=37
 3 16 0.995471 ubox
 4 15 0.997821 ubox
 5 14 0.99887 ubox
@@ -3542,7 +3542,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999879 ubox
 30 36 0.988123 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=17
 3 16 0.998905 ubox
 4 15 0.999434 ubox
 5 14 0.999712 ubox
@@ -3558,7 +3558,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999996 ubox
 30 36 0.99102 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=17
 1 32 0.104201 ubox
 1 50 0.967405 ubox
 2 31 0.104598 ubox
@@ -3586,7 +3586,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 36 47 0.115944 ubox
 37 46 0.115741 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=37
 1 50 0.949244 ubox
 2 49 0.989995 ubox
 3 48 0.999207 ubox
@@ -3630,7 +3630,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 36 47 0.033619 ubox
 37 46 0.0321056 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=37
 3 16 0.989209 ubox
 3 17 0.134366 ubox
 4 15 0.990898 ubox
@@ -3649,7 +3649,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999687 ubox
 30 36 0.951826 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 2 41 0.991155 ubox
 3 40 0.993947 ubox
 4 39 0.996226 ubox
@@ -3673,7 +3673,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.991738 ubox
 56 60 0.946421 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 1 24 0.00441888 ubox
 1 25 0.194177 ubox
 1 31 0.00455579 ubox
@@ -3815,7 +3815,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 44 50 0.00183668 ubox
 45 49 0.00183668 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 1 43 0.117601 ubox
 2 41 0.991155 ubox
 2 42 0.125867 ubox
@@ -3851,7 +3851,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.991738 ubox
 56 60 0.946421 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=0 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=37
 1 43 0.126641 ubox
 2 41 0.98897 ubox
 2 42 0.134751 ubox
@@ -3883,7 +3883,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.970982 ubox
 56 60 0.73975 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=37
 1 43 0.362788 ubox
 2 41 0.941297 ubox
 2 42 0.331368 ubox
@@ -3913,7 +3913,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.985806 ubox
 56 60 0.912446 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=37
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=37
 1 24 0.00231611 ubox
 1 25 0.0723811 ubox
 1 27 0.00168009 ubox
@@ -4165,7 +4165,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 44 50 0.00315003 ubox
 45 49 0.00195514 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle gGGCCGGGCGCGGUGGCGCGCGCCUGUAGUCCCAGCUACUCGGGAGGCUC --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 1 25 0.266294 ubox
 1 32 0.738671 ubox
 1 33 0.325016 ubox
@@ -4213,7 +4213,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 37 46 0.800696 ubox
 39 44 0.301777 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=nodangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=17
 1 21 0.117267 ubox
 3 16 0.995265 ubox
 3 17 0.0915977 ubox
@@ -4237,7 +4237,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 30 36 0.97828 ubox
 31 36 0.0375318 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 3 16 0.997571 ubox
 3 17 0.0522532 ubox
 4 15 0.999071 ubox
@@ -4256,7 +4256,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999975 ubox
 30 36 0.989635 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.01 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=17
 3 16 0.998625 ubox
 4 15 0.999431 ubox
 5 14 0.99971 ubox
@@ -4272,7 +4272,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999994 ubox
 30 36 0.990866 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 1 43 0.204472 ubox
 2 41 0.98067 ubox
 2 42 0.192653 ubox
@@ -4316,7 +4316,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.99163 ubox
 56 60 0.946422 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=overdangle ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=25.9
 1 43 0.197522 ubox
 1 47 0.00302312 ubox
 1 48 0.00197834 ubox
@@ -4432,7 +4432,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.980177 ubox
 56 60 0.795421 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=17
 3 16 0.979646 ubox
 4 15 0.986574 ubox
 5 14 0.992946 ubox
@@ -4448,7 +4448,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999947 ubox
 30 36 0.978282 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner1999.par --temperature=17
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.001 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner1999.par --temperature=17
 3 16 0.979646 ubox
 3 17 0.198158 ubox
 4 15 0.986574 ubox
@@ -4471,7 +4471,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 30 36 0.978282 ubox
 31 36 0.0375318 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate ACCCUACUGUGCUAACCGAACCAGAUAACGGUACAGUAGGGGUAAAUUCUCCGCAUUCGGUGCGGAAAA --bppmThreshold=1e-05 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 1 43 0.132399 ubox
 1 47 0.00320217 ubox
 1 48 0.00173929 ubox
@@ -4569,7 +4569,7 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 55 61 0.991642 ubox
 56 60 0.946433 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=/home/sjanssen//share/gapc/librna/rna_turner2004.par --temperature=25.9
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=outside --allowLP=1 --grammar=microstate AAGGGCGUCGUCGCCCCGAGUCGUAGCAGUUGACUACUGUUAUGU --bppmThreshold=0.1 --dotplot=dotPlot.ps --param=BGAPDIR/share/gapc/librna/rna_turner2004.par --temperature=25.9
 3 16 0.996715 ubox
 4 15 0.99845 ubox
 5 14 0.999203 ubox
@@ -4585,8 +4585,8 @@ No consensus shapes found. Try to increase energy range with --absoluteDeviation
 29 37 0.999975 ubox
 30 36 0.989635 ubox
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=diffSHAPE --normalization=RNAstructure --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=diffSHAPE --normalization=RNAstructure --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                   1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU  30
@@ -4597,8 +4597,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  1.70   -23.5200000  ....(((((((((...)))..))..)).))  []
  8.10  -219.2640000  ..((...))((.((..((...))..)).))  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=CMCT --normalization=logplain --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=CMCT --normalization=logplain --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4608,8 +4608,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 3.10  -1.8273500  ....((((((.........)).)).))...  []
 3.90  -2.6107000  ....(((((((.....))...))).))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -4618,8 +4618,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 -14.40  -3.6478900  ..((((((((((......))))))))..))  []
 -10.40  -4.6685900  ..(((((((((.((...)))))))))..))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=DMS --normalization=RNAstructure --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=DMS --normalization=RNAstructure --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                    1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -4630,8 +4630,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  -8.10  -132.3510000  ..(((((((.((......)).)))))..))  []
  -4.20  -133.4530000  ..(((((((............)))))..))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=logplain --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=logplain --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
               1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4639,8 +4639,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 1.60  2.1939300  ....(((((............))).))...  []
 3.20  0.6793440  ....(((((((.....))...))).))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=unknown --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=unknown --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (2.989 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -4654,8 +4654,8 @@ Cluster info (2.989 avg. iterations for 1000 alternative start points): unpaired
  -9.40   9.4819600  ..((.(((((((....))))).))....))  []
  -6.70   9.2263600  ..((.(((((((....)))))..))...))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=DMS --normalization=RNAstructure --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=DMS --normalization=RNAstructure --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU  30
@@ -4666,8 +4666,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 -2.10  105.3690000  ...(((......))).((...)).......  [][]
 -1.00   93.7143000  ....((..((..((.....))))..))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=logplain --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=logplain --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
               1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4675,8 +4675,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 1.60  2.1939300  ....(((((............))).))...  []
 3.20  0.6793440  ....(((((((.....))...))).))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=unknown --normalization=asProbabilities --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=unknown --normalization=asProbabilities --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4685,8 +4685,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  1.60  1.2000000  ....(((((............))).))...  []
  3.20  0.6000000  ....(((((((.....))...))).))...  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=CMCT --normalization=centroid --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=CMCT --normalization=centroid --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (3.549 avg. iterations for 1000 alternative start points): unpaired = 1.07452, paired = 0.255027
 >unnamed sequence
@@ -4701,8 +4701,8 @@ Cluster info (3.549 avg. iterations for 1000 alternative start points): unpaired
  -9.00   6.9599900  ..((.((((((.((...))))))))...))  []
  -2.70   6.8919300  ..((.(((.((.((...)))).)))...))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=DMS --normalization=logplain --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=DMS --normalization=logplain --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -4711,8 +4711,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 -14.60  -2.7228000  ..((((((((((......))))))))..))  []
 -10.80  -2.8411700  ((((((..(((....))))).)))).....  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=SHAPE --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=SHAPE --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -4726,8 +4726,8 @@ Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired 
  -9.40   9.4819600  ..((.(((((((....))))).))....))  []
  -6.70   9.2263600  ..((.(((((((....)))))..))...))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=unknown --normalization=asProbabilities --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=unknown --normalization=asProbabilities --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU  30
@@ -4740,8 +4740,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  3.80   0.1000000  ..((((...))..)).((...)).......  [][]
  7.60  -0.2000000  ..((...))((.((..((...))..)).))  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU  30
@@ -4753,8 +4753,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  1.50  -0.4705660  ....(((((((((...)))..))..)).))  []
  7.60  -1.0658800  ..((...))((.((..((...))..)).))  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -4769,8 +4769,8 @@ Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired 
  2.20   5.7232500  ....((...)).((..((...))..))...  [][]
  3.00   5.1414500  ..((...)).(((...)))...........  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=SHAPE --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=0 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=SHAPE --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -4785,8 +4785,8 @@ Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired 
  2.20   5.7232500  ....((...)).((..((...))..))...  [][]
  3.00   5.1414500  ..((...)).(((...)))...........  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=centroid --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=centroid --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (2.845 avg. iterations for 1000 alternative start points): unpaired = 0.991433, paired = 0.227229
 >unnamed sequence
@@ -4805,8 +4805,8 @@ Cluster info (2.845 avg. iterations for 1000 alternative start points): unpaired
 10.20   7.8775100  ....(((.((.(.....).))..).).)..  []
 12.70   7.8066500  .(..(((.((.(.....).))..).).).)  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -4828,8 +4828,8 @@ Cluster info (3.01 avg. iterations for 1000 alternative start points): unpaired 
 10.50  11.0088000  ......(.(((.(.....).)......)))  []
 11.20  11.0076000  ......(.((((.....)..)......)))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=RNAstructure --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=RNAstructure --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                   1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4848,8 +4848,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 21.80  -165.6990000  (.(.....)(.((....(...)))))....  [[][]]
 22.70  -197.7110000  ((((....).).(....(...))).)....  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=asProbabilities --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=nodangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=asProbabilities --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4873,8 +4873,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 13.30  -2.4000000  (...)..(((.((....(...))))))...  [][]
 16.10  -2.6000000  (...).((((.((....(...))))))..)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=RNAstructure --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=diffSHAPE --normalization=RNAstructure --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                   1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4904,8 +4904,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 11.80  -738.6480000  (...)..(((.((....(...))))))...  [][]
 15.10  -889.4520000  (...).((((.((....(...))))))..)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=diffSHAPE --normalization=RNAstructure --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-1.2 --modifier=diffSHAPE --normalization=RNAstructure --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                     1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -4924,8 +4924,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
   0.40  -2264.9300000  (((((..((((...).)))).))))(...)  [][]
   4.40  -2304.3400000  (((((.((((...)).).)).))))(...)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=SHAPE --normalization=asProbabilities --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=SHAPE --normalization=asProbabilities --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4949,8 +4949,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 11.80  -2.4000000  (...)..(((.((....(...))))))...  [][]
 15.10  -2.6000000  (...).((((.((....(...))))))..)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=overdangle --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-1.2 --modifier=unknown --normalization=logplain --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU  30
@@ -4970,8 +4970,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 10.80  -4.1602800  (.(((((...).))))((...))).(...)  [[][]][]
 19.90  -4.2703900  ((((...)).)((((..(...))..)).))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=asProbabilities --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=DMS --normalization=asProbabilities --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -4995,8 +4995,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 16.20  -1.3000000  (.((....).)((....(...))).)....  [[][]]
 21.10  -1.7000000  ((((....).).(....(...))).)....  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=asProbabilities --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=asProbabilities --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -5008,8 +5008,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  -6.40  -4.2000000  ((((((.((......)).)).))))(...)  [][]
  -4.60  -4.8000000  (((((..((((....))))).))))(...)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-1.2 --modifier=SHAPE --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (2.961 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -5031,8 +5031,8 @@ Cluster info (2.961 avg. iterations for 1000 alternative start points): unpaired
 10.30  11.0088000  ......(.(((.(.....).)......)))  []
 11.00  11.0076000  ......(.((((.....)..)......)))  []
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=microstate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape AAGGGCGUCGUCGCCCCGAGUCGUAGCAGU --intercept=-0.6 --modifier=diffSHAPE --normalization=centroid --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 Cluster info (2.961 avg. iterations for 1000 alternative start points): unpaired = 1.00903, paired = 0.253127
 >unnamed sequence
@@ -5064,8 +5064,8 @@ Cluster info (2.961 avg. iterations for 1000 alternative start points): unpaired
 17.80   8.1367200  ...(.((.(.(((...)))))..(...)))  [[][]]
 20.10   7.7649200  .(...((.(.(((...)))))..(...)))  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=DMS --normalization=logplain --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=DMS --normalization=logplain --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -5080,8 +5080,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
  -3.80   0.6323370  .(.(...((((....)))))).........  []
  -3.80  -3.0594200  .((((..((((....))))).))).(...)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=SHAPE --normalization=RNAstructure --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=SHAPE --normalization=RNAstructure --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                   1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30
@@ -5154,8 +5154,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
 24.30  -849.6690000  (.(((...).).(....(...))).)....  [[][]]
 24.30  -520.9600000  (.((.(...)).(....(...))).)....  [[][]]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=unknown --normalization=logplain --slope=2.4
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU --intercept=-0.6 --modifier=unknown --normalization=logplain --slope=2.4
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                  1  gGGCCGGGCGCGGUGGCGCGCGCCUGUAGU  30
@@ -5195,8 +5195,8 @@ The following 1 warnings were raised when parsing the reactivity file '/home/sja
   5.40  -6.5815600  (((((.((((...).)).)).))))(...)  [][]
   5.40  -2.3003100  (((((..((...))))).).)....(...)  [][]
 
-#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=unknown --normalization=asProbabilities --slope=1.8
-The following 1 warnings were raised when parsing the reactivity file '/home/sjanssen/Desktop/fold-grammars//Misc/Test-Suite/StefanStyle//cedric.shape':
+#CMD: perl -I ../../Applications/lib/ x86_64-linux-gnu/RNAshapes  --binPath='x86_64-linux-gnu/x86_64-linux-gnu/'  --mode=probing --allowLP=1 --grammar=macrostate --reactivityfilename=ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape ACCCUACUGUGCUAACCGAACCAGAUAACG --intercept=-0.6 --modifier=unknown --normalization=asProbabilities --slope=1.8
+The following 1 warnings were raised when parsing the reactivity file 'ROOTDIR/Misc/Test-Suite/StefanStyle//cedric.shape':
   1) the file contains more reactivities than there are bases in your RNA input sequence. Exceeding reactivities will be ignored.
 >unnamed sequence
                 1  ACCCUACUGUGCUAACCGAACCAGAUAACG  30

--- a/Misc/Test-Suite/StefanStyle/runTests.pl
+++ b/Misc/Test-Suite/StefanStyle/runTests.pl
@@ -32,12 +32,12 @@ $numCPUs = 1 if (not defined $numCPUs);
 if ((not defined $subTask) or ($subTask eq "default")) {
 	# runs for approx. 9min ...
 	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp pknotsRG",   "-s P -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pknotsRG.out") ;
-	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy A", "-s A -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissA.out") if ((not defined $subTask) or ($subTask eq "knots"));
-	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy B", "-s B -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissB.out") if ((not defined $subTask) or ($subTask eq "knots"));
-	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy C", "-s C -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissC.out") if ((not defined $subTask) or ($subTask eq "knots"));
-	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy D", "-s D -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissD.out") if ((not defined $subTask) or ($subTask eq "knots"));
-	checkParameters("pseudoknots parameter check", $TMPDIR."/".$Settings::ARCHTRIPLE.'/'.$Settings::PROGINFOS{'pkiss'}->{name}."_mfe", "pseudoknots.parametercheck.out") if ((not defined $subTask) or ($subTask eq "knots"));
-	checkBasicFunctions("basic pseudoknot functions", "pseudoknots.basic.out") if ((not defined $subTask) or ($subTask eq "knots"));
+	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy A", "-s A -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissA.out");
+	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy B", "-s B -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissB.out");
+	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy C", "-s C -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissC.out");
+	checkPseudoknotMFEPP("pseudoknots.fasta", "pseudoknots mfe*pp strategy D", "-s D -P $Settings::RNAPARAM1999", "pseudoknots.fasta.mfepp.pKissD.out");
+	checkParameters("pseudoknots parameter check", $TMPDIR."/".$Settings::ARCHTRIPLE.'/'.$Settings::PROGINFOS{'pkiss'}->{name}."_mfe", "pseudoknots.parametercheck.out");
+	checkBasicFunctions("basic pseudoknot functions", "pseudoknots.basic.out");
 	# ... + 4min on Travis, thus combining here
 	checkProbing($TMPDIR, "probing.out", "probing algebra");
 }


### PR DESCRIPTION
I saw that currently a failing test of the "StefanStyle" Perl section will not be reported as non-zero exit code, i.e. although failing Travis will mark the test as passed.
Furthermore, I saw that some tests are never executed (those with "knots" task) since their if condition was never reached.

Each test is a set of commands whose STDOUT results are collated in xxx.run files. Afterwards the file content is compared via `diff` with a pre-recorded truth version of the xxx.run file. Up to now, I excluded the CMD line, due to differing file paths. With this PR I changed the truth value of the file paths to variables (BGAPDIR and ROOTDIR) such that different file path prefixes should no longer be flagged as differences. On the other hand, lines reporting about clustering results are now excluded, since their result is algorithmically instable, i.e. selection of co-optimals is non deterministic.

This PR is a beast, because I had to systematically update the truth files, resulting in large diffs :-/