### PR TITLE
fix #14 segfaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_install:
   - sudo apt-get update -y
   - sudo apt-get install flex bison make libboost-all-dev libgsl-dev ghc
-  - git clone --branch codestyle https://github.com/jlab/gapc /home/travis/gapc
+  - git clone --branch master https://github.com/jlab/gapc /home/travis/gapc
   - pushd .
   - cd /home/travis/gapc
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_install:
   - sudo apt-get update -y
   - sudo apt-get install flex bison make libboost-all-dev libgsl-dev ghc
-  - git clone https://github.com/jlab/gapc /home/travis/gapc
+  - git clone --branch codestyle https://github.com/jlab/gapc /home/travis/gapc
   - pushd .
   - cd /home/travis/gapc
   - ./configure

--- a/Algebras/Shapes/Parts/algpart_shape1_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shape1_basic.gap
@@ -1,4 +1,4 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t sadd(Subsequence b, shape_t e) {
     if (front(e) == '_') {
@@ -28,30 +28,30 @@
   }
 
   shape_t bl(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rb) {
-    return openParen + '_' + e + closeParen;
+    return shape_t(openParen) + '_' + e + shape_t(closeParen);
   }
 
   shape_t br(Subsequence lb,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + e + '_' + closeParen;
+    return shape_t(openParen) + e + '_' + shape_t(closeParen);
   }
 
   shape_t il(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + '_' + e + '_' + closeParen;
+    return shape_t(openParen) + '_' + e + '_' + shape_t(closeParen);
   }
 
   shape_t mldr(Subsequence lb,shape_t e,Subsequence dr,Subsequence rb) {
     if (back(e) == '_') {
-      return openParen + e + closeParen;
+      return shape_t(openParen) + e + shape_t(closeParen);
     } else {
-      return openParen + e + shape_t('_') + closeParen; //cannot happen in macrostates, because this is handled in the mladr case
+      return shape_t(openParen) + e + shape_t('_') + shape_t(closeParen); //cannot happen in macrostates, because this is handled in the mladr case
     }
   }
 
   shape_t mldl(Subsequence lb,Subsequence dl,shape_t e,Subsequence rb) {
     if (front(e) == '_') {
-      return openParen + e + closeParen;
+      return shape_t(openParen) + e + shape_t(closeParen);
     } else {
-      return openParen + shape_t('_') + e + closeParen; //cannot happen in macrostates, because this is handled in the mladl case
+      return shape_t(openParen) + shape_t('_') + e + shape_t(closeParen); //cannot happen in macrostates, because this is handled in the mladl case
     }
   }
 
@@ -65,9 +65,9 @@
     if (back(res) != '_') {
       res = res + shape_t('_'); //cannot happen in macrostates
     }
-    return openParen + res + closeParen;
+    return shape_t(openParen) + res + shape_t(closeParen);
   }
-  
+
   shape_t addss(shape_t x,Subsequence rb) {
     if (back(x) == '_') {
       return x;

--- a/Algebras/Shapes/Parts/algpart_shape2_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shape2_basic.gap
@@ -1,13 +1,13 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t bl(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rb) {
-    return openParen + '_' + e + closeParen;
+    return shape_t(openParen) + '_' + e + shape_t(closeParen);
   }
 
   shape_t br(Subsequence lb,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + e + '_' + closeParen;
+    return shape_t(openParen) + e + '_' + shape_t(closeParen);
   }
 
   shape_t il(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + '_' + e + '_' + closeParen;
+    return shape_t(openParen) + '_' + e + '_' + shape_t(closeParen);
   }

--- a/Algebras/Shapes/Parts/algpart_shape3_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shape3_basic.gap
@@ -1,13 +1,13 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t bl(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t br(Subsequence lb,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
-  
+
   shape_t il(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }

--- a/Algebras/Shapes/Parts/algpart_shape4_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shape4_basic.gap
@@ -1,5 +1,5 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t il(Subsequence lb,Subsequence lregion,shape_t e,Subsequence rregion,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }

--- a/Algebras/Shapes/Parts/algpart_shape5_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shape5_basic.gap
@@ -1,8 +1,8 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t sadd(Subsequence b, shape_t e) {
     shape_t emptyShape;
-    
+
     if (e == emptyShape) {
       return '_' + e;
     } else {
@@ -48,7 +48,7 @@
   }
 
   shape_t hl(Subsequence lb,Subsequence region,Subsequence rb) {
-    return openParen + closeParen;
+    return shape_t(openParen) + shape_t(closeParen);
   }
 
 
@@ -65,23 +65,23 @@
   }
 
   shape_t ml(Subsequence lb,shape_t e,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t mlall(Subsequence lb,shape_t e,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t mldr(Subsequence lb,shape_t e,Subsequence dr,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t mldlr(Subsequence lb,Subsequence dl,shape_t e,Subsequence dr,Subsequence rb) {
-    return openParen + e+ closeParen;
+    return shape_t(openParen) + e+ shape_t(closeParen);
   }
 
   shape_t mldl(Subsequence lb,Subsequence dl,shape_t e,Subsequence rb) {
-    return openParen + e+ closeParen;
+    return shape_t(openParen) + e+ shape_t(closeParen);
   }
 
   shape_t addss(shape_t e,Subsequence rb) {

--- a/Algebras/Shapes/Parts/algpart_shapeX_basic.gap
+++ b/Algebras/Shapes/Parts/algpart_shapeX_basic.gap
@@ -1,8 +1,8 @@
-//openParen and closeParen are defined in Extensions/shapes.hh as '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
+//openParen and closeParen are defined in Extensions/shapes.hh as char '[' ']' and in Extensions/pknot_shape.hh as '(' ')'
 
   shape_t sadd(Subsequence b, shape_t x) {
     shape_t emptyShape;
-    
+
     if (x == emptyShape) {
       return shape_t('_');
     } else {
@@ -26,7 +26,7 @@
 		  return le;
 		} else {
 		  return le + re;
-		}			
+		}
 	}
   }
 
@@ -72,17 +72,17 @@
   }
 
   shape_t hl(Subsequence lb,Subsequence region,Subsequence rb) {
-    return openParen + closeParen;
+    return shape_t(openParen) + shape_t(closeParen);
   }
 
 
   shape_t bl(Subsequence lb,Subsequence lregion,shape_t x,Subsequence rb) {
 	if (shapelevel() <= 3) {
 		shape_t res;
-		append(res, openParen);
+		append(res, shape_t(openParen));
 		if (shapelevel() <= 2) { append(res, '_'); }
 		append(res, x);
-		append(res, closeParen);
+		append(res, shape_t(closeParen));
 		return res;
 	} else {
 		return x;
@@ -92,10 +92,10 @@
   shape_t br(Subsequence lb,shape_t x,Subsequence rregion,Subsequence rb) {
 	if (shapelevel() <= 3) {
 		shape_t res;
-		append(res, openParen);
+		append(res, shape_t(openParen));
 		append(res, x);
 		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, closeParen);
+		append(res, shape_t(closeParen));
 		return res;
 	} else {
 		return x;
@@ -105,11 +105,11 @@
   shape_t il(Subsequence lb,Subsequence lregion,shape_t x,Subsequence rregion,Subsequence rb) {
 	if (shapelevel() <= 4) {
 		shape_t res;
-		append(res, openParen);
+		append(res, shape_t(openParen));
 		if (shapelevel() <= 2) { append(res, '_'); }
 		append(res, x);
 		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, closeParen);
+		append(res, shape_t(closeParen));
 		return res;
 	} else {
 		return x;
@@ -117,39 +117,39 @@
   }
 
   shape_t ml(Subsequence lb,shape_t e,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t mlall(Subsequence lb,shape_t e,Subsequence rb) {
-    return openParen + e + closeParen;
+    return shape_t(openParen) + e + shape_t(closeParen);
   }
 
   shape_t mldr(Subsequence lb,shape_t e,Subsequence dr,Subsequence rb) {
 	  shape_t res;
-	  append(res, openParen);
+	  append(res, shape_t(openParen));
 	  append(res, e);
 	  if ((shapelevel() == 1) && (back(e) != '_')) { append(res, '_'); }
-	  append(res, closeParen);
+	  append(res, shape_t(closeParen));
 	  return res;
   }
 
   shape_t mldlr(Subsequence lb,Subsequence dl,shape_t e,Subsequence dr,Subsequence rb) {
 	  shape_t res;
-	  append(res, openParen);
+	  append(res, shape_t(openParen));
 	  if ((shapelevel() == 1) && (front(e) != '_')) { append(res, '_'); }
 	  append(res, e);
 	  if ((shapelevel() == 1) && (back(e) != '_')) { append(res, '_'); }
-	  append(res, closeParen);
+	  append(res, shape_t(closeParen));
 	  return res;
-	  
+
   }
 
   shape_t mldl(Subsequence lb,Subsequence dl,shape_t e,Subsequence rb) {
 	  shape_t res;
-	  append(res, openParen);
+	  append(res, shape_t(openParen));
 	  if ((shapelevel() == 1) && (front(e) != '_')) { append(res, '_'); }
 	  append(res, e);
-	  append(res, closeParen);
+	  append(res, shape_t(closeParen));
 	  return res;
   }
 

--- a/Extensions/pknot_shape.hh
+++ b/Extensions/pknot_shape.hh
@@ -1,5 +1,5 @@
-#ifndef RTLIB_SHAPE_HH_  // SMJ 2020-11-14: don't know why, but must be identical to FLAG in gapc/rtlib/shape.hh
-#define RTLIB_SHAPE_HH_
+#ifndef PKNOT_SHAPE_HH
+#define PKNOT_SHAPE_HH
 
 template<typename alphabet, typename pos_type, typename T>
 inline bool midsize(const Basic_Sequence<alphabet, pos_type> &seq, T i, T j, int a, int l) {
@@ -110,7 +110,7 @@ inline SHAPE tail(const SHAPE &a) {
 
 typedef shape_t myShape;
 
-static const shape_t openParen = '(';
-static const shape_t closeParen = ')';
+static const char openParen = '(';
+static const char closeParen = ')';
 
 #endif

--- a/Extensions/pknot_shape.hh
+++ b/Extensions/pknot_shape.hh
@@ -1,5 +1,5 @@
-#ifndef PKNOT_SHAPE_HH
-#define PKNOT_SHAPE_HH
+#ifndef RTLIB_SHAPE_HH_  // SMJ 2020-11-14: don't know why, but must be identical to FLAG in gapc/rtlib/shape.hh
+#define RTLIB_SHAPE_HH_
 
 template<typename alphabet, typename pos_type, typename T>
 inline bool midsize(const Basic_Sequence<alphabet, pos_type> &seq, T i, T j, int a, int l) {

--- a/Extensions/shapes.hh
+++ b/Extensions/shapes.hh
@@ -1,5 +1,5 @@
-#ifndef SHAPE_HH_
-#define SHAPE_HH_
+#ifndef SHAPES_HH
+#define SHAPES_HH
 
 static const char openParen = '[';
 static const char closeParen = ']';

--- a/Extensions/shapes.hh
+++ b/Extensions/shapes.hh
@@ -1,7 +1,7 @@
-#ifndef RTLIB_SHAPE_HH_  // SMJ 2020-11-14: don't know why, but must be identical to FLAG in gapc/rtlib/shape.hh
-#define RTLIB_SHAPE_HH_
+#ifndef SHAPE_HH_
+#define SHAPE_HH_
 
-static const shape_t openParen = '[';
-static const shape_t closeParen = ']';
+static const char openParen = '[';
+static const char closeParen = ']';
 
 #endif

--- a/Extensions/shapes.hh
+++ b/Extensions/shapes.hh
@@ -1,4 +1,4 @@
-#ifndef RTLIB_SHAPE_HH_  # SMJ: don't know why, but must be identical to FLAG in gapc/rtlib/shape.hh
+#ifndef RTLIB_SHAPE_HH_  // SMJ 2020-11-14: don't know why, but must be identical to FLAG in gapc/rtlib/shape.hh
 #define RTLIB_SHAPE_HH_
 
 static const shape_t openParen = '[';

--- a/Misc/Applications/lib/foldGrammars/Settings.pm
+++ b/Misc/Applications/lib/foldGrammars/Settings.pm
@@ -6,18 +6,18 @@ use warnings;
 package Settings;
 
 our %PROGINFOS = (
-	'rnashapes', 				{date => '01.10.2015', version => '3.3.0', name => 'RNAshapes', packageDir => 'RNAshapes/'},
-	'rnaalishapes', 			{date => '20.03.2015', version => '2.4.7', name => 'RNAalishapes', packageDir => 'RNAalishapes/'},
-	'pkiss', 						{date => '20.03.2015', version => '2.2.12', name => 'pKiss', packageDir => 'pKiss/'},
-	'palikiss',					{date => '20.03.2015', version => '1.0.7', name => 'pAliKiss', packageDir => 'pAliKiss/'},
-	'libfoldgrammars', 	{date => '01.10.2015', version => '1.2.0', name => 'libfoldgrammars', packageDir => 'libfoldGrammars/'},
-	'rapidshapes', 			{date => '20.03.2015', version => '2.0.9', name => 'RapidShapes', packageDir => 'RapidShapes/'},
-	'knotinframe', 			{date => '20.03.2015', version => '2.0.8', name => 'knotinframe', packageDir => 'Knotinframe/'},
-	'rapidshapestest', 	{date => '01.03.2013', version => '2.1.0', name => 'RapidShapes-Test'},
-	'getoutsidetruth', 	{date => '19.04.2013', version => '1.0.0', name => 'getOutsideTruth'},
-	'acms',							{date => '21.03.2015', version => '1.2.1', name => 'acms', packageDir => 'aCMs/'},
-	'acmbuild', 					{date => '21.11.2014', version => '1.1.1', name => 'acmbuild'},
-	'acmsearch', 				{date => '21.11.2014', version => '1.1.1', name => 'acmsearch'},
+	'rnashapes', 				 {date => '18.11.2020', version => '3.3.1', name => 'RNAshapes', packageDir => 'RNAshapes/'},
+	'rnaalishapes', 		 {date => '18.11.2020', version => '2.4.8', name => 'RNAalishapes', packageDir => 'RNAalishapes/'},
+	'pkiss', 						 {date => '18.11.2020', version => '2.2.13', name => 'pKiss', packageDir => 'pKiss/'},
+	'palikiss',					 {date => '18.11.2020', version => '1.0.8', name => 'pAliKiss', packageDir => 'pAliKiss/'},
+	'libfoldgrammars', 	 {date => '01.10.2015', version => '1.2.0', name => 'libfoldgrammars', packageDir => 'libfoldGrammars/'},
+	'rapidshapes', 			 {date => '18.11.2020', version => '2.0.10', name => 'RapidShapes', packageDir => 'RapidShapes/'},
+	'knotinframe', 			 {date => '20.03.2015', version => '2.0.8', name => 'knotinframe', packageDir => 'Knotinframe/'},
+	'rapidshapestest', 	 {date => '01.03.2013', version => '2.1.0', name => 'RapidShapes-Test'},
+	'getoutsidetruth', 	 {date => '19.04.2013', version => '1.0.0', name => 'getOutsideTruth'},
+	'acms',							 {date => '21.03.2015', version => '1.2.1', name => 'acms', packageDir => 'aCMs/'},
+	'acmbuild', 				 {date => '21.11.2014', version => '1.1.1', name => 'acmbuild'},
+	'acmsearch', 				 {date => '21.11.2014', version => '1.1.1', name => 'acmsearch'},
 	'locomotif_wrapper', {date => '16.01.2015', version => '1.0.0', name => 'Locomotif_wrapper'},
 );
 
@@ -102,7 +102,7 @@ our $MODIFIER_UNKNOWN = 'unknown';
 our %RAPIDSHAPES_BIBISERV = (
 	'clusterwide_tempdir', '/vol/tmp/',
 	'tdmwrapper_binary', '/vol/fold-grammars/src/Misc/Applications/RapidShapes/tdmwrapper',
-	'binPath_grammargenerator', '/vol/fold-grammars/bin/', 
+	'binPath_grammargenerator', '/vol/fold-grammars/bin/',
 	'qsub', 'qsub -l virtual_free=6GB -l h_vmem=6GB -cwd -tc 10 ', #-tc controls the number of maximal parallel jobs for an array-job
 	'gridSH', '/usr/bin/sh',
 	'sleepTimeInit', '1', #initial number of seconds between two qstat requests
@@ -114,9 +114,9 @@ our %RAPIDSHAPES_BIBISERV = (
 my %checkedBinaries = (); #run time hash to avoid multiple check for binaries
 sub getBinary {
 	my ($requestedBinary) = @_;
-	
+
 	return $checkedBinaries{$requestedBinary} if (exists $checkedBinaries{$requestedBinary});
-	
+
 	my $binary = $requestedBinary;
 	$binary = $BINARIES{$requestedBinary} if (exists $BINARIES{$requestedBinary});
 	my $whichResult = qx(which $binary 2>&1);


### PR DESCRIPTION
@fncnt reported that compiled binaries crash with segmentation faults if compiled with more recent versions of GCC and libc. I could reproduce this problem even for empty input sequences!
I still don't fully understand the problem, but my workaround seems to fix this issue: I changes the type of the `openParen` and `closeParen` global variables from `shape_t` to `char` to avoid issues that might arise from data type constructors. Therefore, I had to explicitly "cast" the data type in the shape algebras.
This PR bumps the version numbers of programs using shape algebras by 0.0.1.