### PR TITLE
testing gap base pair probs

### DIFF
--- a/Misc/Test-Suite/StefanStyle/tail.clustal
+++ b/Misc/Test-Suite/StefanStyle/tail.clustal
@@ -1,0 +1,7 @@
+CLUSTAL X (1.81) multiple sequence alignment
+
+
+
+tail                                ----------------------------------------TGGCCACTAT
+
+tail                                TTAAGCAAGTTACGGGCGCTCATTTATTCG


### PR DESCRIPTION
this PR is in line with future changes in the Vienna package, for details see https://github.com/ViennaRNA/ViennaRNA/issues/136
Briefly, we need to change `>` into `>=` to disable base pair probabilities for the edge case alignments with only one row between two gap bases.