### PR TITLE
removing a duplicate ill defined function

### DIFF
--- a/Extensions/rnaoptions_defaults.hh
+++ b/Extensions/rnaoptions_defaults.hh
@@ -142,8 +142,6 @@
 	inline static const char* getProbing_normalization() {
 		return "centroid";
 	}
-	inline static const char* getProbingDataFilename() {
-	}
 	inline static int getConsensusType() {
 		return 0;
 	}


### PR DESCRIPTION
I spotted some compiler warnings. Reason is the ill defined function `getProbingDataFilename` which also seems to be a duplicate of `getProbing_dataFilename`. I could not find any code that is using `getProbingDataFilename` - thus we should delete it altogether.