### PR TITLE
avoid recalculating scores in getReactivityScore 

### DIFF
--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -163,7 +163,8 @@ inline double CalculatePseudoEnergy(double data, const std::string &modifier,
                                     double slope, double intercept) {
   static const double (*params)[8];
   static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
-                                                 0.0830320205572, 0.0,
+                                                 0.0830320205572,
+                                                 1.82374892807, 0.0,
                                                  0.0830320205572,
                                                  1.82374892807, 0.0},
                                                 {1.27932240423, 0.0,

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -267,7 +267,6 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq,
                                  const bool offset) {
-
   static bool isLoaded = false;
   static std::vector<double> off_probingData;
   static std::vector<double> probingData;

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -282,7 +282,10 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
      -store only the upper triangular matrix (as a 1d-array)
      ->makes figuring out the correct indices a bit more
        complicated and adds slightly more compute compared
-       to using a NxN array, but roughly cuts the required memory in half */
+       to using a NxN array, but roughly cuts the required memory in half
+      -the offset parameter is only true in two-track mode (see overloads
+       below), so the creation of a second array for offset score
+       lookups is only done if the offset parameter is true */
 
   static unsigned int iLen = inputSubseq.seq->n + 1;
   static unsigned int oLen = offsetSubseq.seq->n + 1;

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -1,896 +1,499 @@
 #ifndef PROBING_HH
 #define PROBING_HH
 
+#include <time.h>
+#include <utility>
+#include <vector>
 #include <iostream>
 #include <fstream>
 #include <string>
-#include <time.h>
 
-#define ARRAYLOOKUP // use array to store calc results
-
-#ifdef ARRAYLOOKUP
-// can use TRIU_ONLY and/or PRECALC in combination w/ ARRAYLOOKUP
-#define TRIU_ONLY // only store the upper triangular matrix for the scores lookup (more complicated indexing, half the memory)
-//#define PRECALC // precalculate everything and store results in array
-#endif
-
-//#define HASHLOOKUP // use hashmap to store calc results
-
-#ifdef HASHLOOKUP
-//#define PRINT_INFO // turn on to print debugging information in hash lookup version
-#endif
-
-/*
-  Fynn's improvements/suggestions:
-
-  -minor adjustments:
-	-replace vector.at(i) w/ vector[i] (faster)
-
-	-kmeans:
-		-allocate centroid-related arrays on stack (if kmeans is never used for clustering of too many clusters)
-
-	-CalculatePseudoEnergy:
-		-convert std::vector(s) to constant stack-allocated arrays
-	
-	-GetReactivityScore:
-		-pass "probingData" vector (and "modifier" string) to calculateScore by reference (makes code about 0.05x- 0.1x faster)
-		-replace reversing of probingData to off_probingData w/ 
-		 vector<double> off_probingData(probingData.rbegin(), probingData.rend()); probingData.clear();
-  
-  -major adjustments:
-	-GetReactivityScore (hash version):
-		-keep track of already calculated scores by hashing the function parameters and
-	  	 performing a simple hashmap lookup to see if the function was aleady called once
-	  	 w/ the same parameters (separately for inputSubseq and offsetSubseq);
-		 if so, simply return the previously calculated result 
-		-makes code about about 5-10x faster, speedup seems to grow expontentially w/ input
-
-	-GetReactivityScore (array version):
-		-store previously calculated results in one (single track) or two (two track) matrices
-		 and simply retrieve the previously calculated results if they exist
-		-makes code about 1.5-2x faster the the hash version
-		-optional: 
-			-calculate all possible scores once and only do lookups whenever the
-		     function is called after the initial calculation (slower than adding scores dynamically)
-			-store only the upper triangular matrix to store the results
-			 (makes calculating the correct indices more complicated,
-			  but only requires half the memory and is slightly faster)
-*/
-
-//Stefans own 1-dimensional k-means clustering
-inline void kmeans(int numCluster, int numData, double *input, double centroids[]) {
+// Stefans own 1-dimensional k-means clustering
+inline void kmeans(int numCluster, int numData, double *input,
+                   double centroids[]) {
   const int MAXRUNS = 1000;
-	const int MAXITERATIONS = 100;
-	const double CONVERGENCE = 0.01;
+  const int MAXITERATIONS = 100;
+  const double CONVERGENCE = 0.01;
 
-	int i, j, k, r = 0;
-	srand (time(NULL));
+  int i, j, k, r = 0;
+  srand(time(NULL));
 
-	int sumRunIterations = 0;
-	if (numData >= numCluster) {
-		double clusterSumDistances[numCluster];
-		double bestCentroids[numCluster];
-		int numClusterMembers[numCluster];
-		double bestVariance = static_cast<double>(HUGE_VAL);
-		int *assignments = new int[numData];
-		double minDist_point2cluster = static_cast<double>(HUGE_VAL);
-		int minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
-		double dist_point2cluster = static_cast<double>(HUGE_VAL);
-		double variance = static_cast<double>(HUGE_VAL);
-		double newVariance = static_cast<double>(HUGE_VAL);
-		int randomIndex = 0;
-		int iteration = 1;
-		double varianceChange = static_cast<double>(HUGE_VAL);
+  int sumRunIterations = 0;
+  if (numData >= numCluster) {
+    double *clusterSumDistances = static_cast<double *>(malloc(
+      sizeof(double) * numCluster));
+    double *bestCentroids = static_cast<double *>(
+      malloc(sizeof(double) * numCluster));
+    double bestVariance = static_cast<double>(HUGE_VAL);
+    int *assignments = static_cast<int *>(malloc(sizeof(int) * numData));
+    int *numClusterMembers = static_cast<int *>(
+      malloc(sizeof(int) * numCluster));
+    double minDist_point2cluster = static_cast<double>(HUGE_VAL);
+    int minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
+    double dist_point2cluster = static_cast<double>(HUGE_VAL);
+    double variance = static_cast<double>(HUGE_VAL);
+    double newVariance = static_cast<double>(HUGE_VAL);
+    int randomIndex = 0;
+    int iteration = 1;
+    double varianceChange = static_cast<double>(HUGE_VAL);
 
-		for (r = 0; r < MAXRUNS; r++) {
-			// select random data points as initial centroids
-			for (k = 0; k < numCluster; k++) {
-				randomIndex = ((int) (rand() % numData));
-				centroids[k] = input[randomIndex];
-			}
+    for (r = 0; r < MAXRUNS; r++) {
+      // select random data points as initial centroids
+      for (k = 0; k < numCluster; k++) {
+        randomIndex = static_cast<int>(rand() % numData);
+        centroids[k] = input[randomIndex];
+      }
 
-			iteration = 1;
-			variance = HUGE_VAL;
-			while (iteration < MAXITERATIONS) {
-				// find for each point in the input the clostest centroid and save the centroid index as the assignment
-				for (i = 0; i < numData; i++) {
-					minDist_point2cluster = static_cast<int>(HUGE_VAL);
-					minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
-					for (k = 0; k < numCluster; k++) {
-						dist_point2cluster = pow(input[i] - centroids[k], 2);
-						if (dist_point2cluster < minDist_point2cluster) {
-							minDist_point2cluster = dist_point2cluster;
-							minDistIndex_point2cluster = k;
-						}
-					}
-					assignments[i] = minDistIndex_point2cluster;
-				}
+      iteration = 1;
+      variance = HUGE_VAL;
+      while (iteration < MAXITERATIONS) {
+        /* find for each point in the input the clostest centroid and save the
+           centroid index as the assignment */
+        for (i = 0; i < numData; i++) {
+          minDist_point2cluster = static_cast<int>(HUGE_VAL);
+          minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
+          for (k = 0; k < numCluster; k++) {
+            dist_point2cluster = pow(input[i] - centroids[k], 2);
+            if (dist_point2cluster < minDist_point2cluster) {
+              minDist_point2cluster = dist_point2cluster;
+              minDistIndex_point2cluster = k;
+            }
+          }
+          assignments[i] = minDistIndex_point2cluster;
+        }
 
-				// update centroids according to the new assignment
-				for (k = 0; k < numCluster; k++) {
-					clusterSumDistances[k] = 0;
-					numClusterMembers[k] = 0;
-				}
-				for (i = 0; i < numData; i++) {
-					clusterSumDistances[assignments[i]] += input[i];
-					numClusterMembers[assignments[i]] ++;
-				}
-				for (k = 0; k < numCluster; k++) {
-					if (numClusterMembers[k] > 0) {
-						centroids[k] = clusterSumDistances[k] / numClusterMembers[k];
-					} else {
-						centroids[k] = 0;
-					}
-				}
+        // update centroids according to the new assignment
+        for (k = 0; k < numCluster; k++) {
+          clusterSumDistances[k] = 0;
+          numClusterMembers[k] = 0;
+        }
+        for (i = 0; i < numData; i++) {
+          clusterSumDistances[assignments[i]] += input[i];
+          numClusterMembers[assignments[i]]++;
+        }
+        for (k = 0; k < numCluster; k++) {
+          if (numClusterMembers[k] > 0) {
+            centroids[k] = clusterSumDistances[k] / numClusterMembers[k];
+          } else {
+            centroids[k] = 0;
+          }
+        }
 
-				// compute overall cluster variance as a quality measure for the clustering
-				newVariance = 0;
-				for (i = 0; i < numData; i++) {
-					newVariance += pow(input[i] - centroids[assignments[i]],2);
-				}
+        /* compute overall cluster variance as a quality measure for the
+           clustering */
+        newVariance = 0;
+        for (i = 0; i < numData; i++) {
+          newVariance += pow(input[i] - centroids[assignments[i]], 2);
+        }
 
-				// stop clustering if change between two iterations is too small
-				varianceChange = variance - newVariance;
-				variance = newVariance;
-				if (varianceChange < CONVERGENCE) {
-					break;
-				}
-				iteration++;
-			}
-			sumRunIterations += iteration;
-			if (variance < bestVariance) {
-				for (k = 0; k < numCluster; k++) {
-					bestCentroids[k] = centroids[k];
-				}
-				bestVariance = variance;
-			}
-		}
+        // stop clustering if change between two iterations is too small
+        varianceChange = variance - newVariance;
+        variance = newVariance;
+        if (varianceChange < CONVERGENCE) {
+          break;
+        }
+        iteration++;
+      }
+      sumRunIterations += iteration;
+      if (variance < bestVariance) {
+        for (k = 0; k < numCluster; k++) {
+          bestCentroids[k] = centroids[k];
+        }
+        bestVariance = variance;
+      }
+    }
 
-		for (k = 0; k < numCluster; k++) {
-			centroids[k] = bestCentroids[k];
-		}
-
-		delete[] assignments;
-	} 
-	else {
-		for (k = 0; k < numCluster; k++) {
-			centroids[k] = 1 / numCluster * k;
-		}
-	}
+    for (k = 0; k < numCluster; k++) {
+      centroids[k] = bestCentroids[k];
+    }
+  } else {
+    for (k = 0; k < numCluster; k++) {
+      centroids[k] = 1 / numCluster * k;
+    }
+  }
 
 
-	//for return: the cluster for the unpaired probing values always comes first, i.e. 0 = unpaired = higher value; 1 = paired = lower value
-	if (centroids[0] < centroids[1]) {
-		double help = centroids[0];
-		centroids[0] = centroids[1];
-		centroids[1] = help;
-	}
+  /* for return: the cluster for the unpaired probing values always comes first,
+     i.e. 0 = unpaired = higher value; 1 = paired = lower value */
+  if (centroids[0] < centroids[1]) {
+    double help = centroids[0];
+    centroids[0] = centroids[1];
+    centroids[1] = help;
+  }
 
-	//centroids[0] = 2.1133;
-	//centroids[1] = 0.116405;
-	std::cout << "Cluster info (" << ((sumRunIterations/((double) MAXRUNS))) << " avg. iterations for "<< MAXRUNS << " alternative start points): unpaired = " << centroids[0] << ", paired = " << centroids[1] << "\n";
+  // centroids[0] = 2.1133;
+  // centroids[1] = 0.116405;
+  std::cout << "Cluster info ("
+            << (sumRunIterations/static_cast<double>(MAXRUNS))
+            << " avg. iterations for "<< MAXRUNS
+            << " alternative start points): unpaired = " << centroids[0]
+            << ", paired = " << centroids[1] << "\n";
 }
 
 // START: STOLEN FROM RNASTRUCTURE
-inline double Gammadist(double data, double shape, double loc, double scale){
-	return (1/scale)*pow((data - loc)*(1/scale), (shape - 1))*exp(-(1/scale)*(data - loc))/tgamma(shape);
+inline double Gammadist(double data, double shape, double loc, double scale) {
+  return (1 / scale) * pow((data - loc) * (1 / scale), (shape - 1)) * \
+         exp(-(1 / scale) * (data - loc)) / tgamma(shape);
 }
 
-inline double Potential(double data, const double (*params)[8], double kT)
-{
-	std::cout << "calling new Potential function" << std::endl;
-	// params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for shape, loc scale of component 1
-	// j=3,4,5 for shape, loc, scale of component 2 and j=6,7 for weights of components 1 and 2 respectively.
-	double pairedprob = params[0][6] * Gammadist(data, params[0][0], params[0][1], params[0][2]) +
-	                    params[0][7] * Gammadist(data, params[0][3], params[0][4], params[0][5]);
-	double unpairedprob = params[1][6] * Gammadist(data, params[1][0], params[1][1], params[1][2]) +
-	                      params[1][7] * Gammadist(data, params[1][3], params[1][4], params[1][5]);
-
-	return -kT * log(pairedprob / unpairedprob);
+inline double Potential(double data, const double (*params)[8],
+                        double kT) {
+  /* params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for
+     shape, loc scale of component 1
+     j=3,4,5 for shape, loc, scale of component 2 and j=6,7 for weights of
+     components 1 and 2 respectively. */
+  double pairedprob = params[0][6]*Gammadist(data, params[0][0], params[0][1],
+                                             params[0][2]) +
+                      params[0][7]*Gammadist(data, params[0][3], params[0][4],
+                                             params[0][5]);
+  double unpairedprob = params[1][6]*Gammadist(data, params[1][0], params[1][1],
+                                               params[1][2]) +
+                        params[1][7]*Gammadist(data, params[1][3], params[1][4],
+                                               params[1][5]);
+  return -kT*log(pairedprob/unpairedprob);
 }
 
-// This function calculates the pseudoenergy for a given reactivity data. It changes the calculation
-// depending on the modifier specified, giving either the log-likelihood-ratio of the unpaired/paired
-// probabilities given a reactivity distribution per modifier, or the "classic" Deigan et al. bonus
-// term when no modifier or an unrecognized modifier is provided.
-inline double CalculatePseudoEnergy(double data, std::string modifier, double slope, double intercept) 
+/* This function calculates the pseudoenergy for a given reactivity data. It
+   changes the calculation depending on the modifier specified, giving either
+   the log-likelihood-ratio of the unpaired/paired probabilities given a
+   reactivity distribution per modifier, or the "classic" Deigan et al. bonus
+   term when no modifier or an unrecognized modifier is provided. */
+inline double CalculatePseudoEnergy(double data, std::string &modifier,
+                                    double slope, double intercept) 
 {
 	static const double (*params)[8];
-	static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0, 0.0830320205572, 0.0,
-											   0.0830320205572, 1.82374892807, 0.0}, 
-											   {1.27932240423, 0.0, 0.374470347084, 1.27932240423,
-											   0.0, 0.374470347084, 1.27932240423, 0.0}};
+	static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
+                                                 0.0830320205572, 0.0,
+											                           0.0830320205572,
+                                                 1.82374892807, 0.0}, 
+											                          {1.27932240423, 0.0,
+                                                 0.374470347084, 1.27932240423,
+											                           0.0, 0.374470347084,
+                                                 1.27932240423, 0.0}};
 
-	static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0, 0.0876565404957, 1.36184674022,
-												0.0, 0.0876565404957, 1.36184674022, 0.0},
-												{1.33486621438, 0.0, 0.37015874678, 1.33486621438,
-												0.0, 0.37015874678, 1.33486621438, 0.0}};
+	static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0,
+                                               0.0876565404957, 1.36184674022,
+												                       0.0, 0.0876565404957,
+                                               1.36184674022, 0.0},
+												                      {1.33486621438, 0.0,
+                                               0.37015874678, 1.33486621438,
+												                       0.0, 0.37015874678,
+                                               1.33486621438, 0.0}};
 
-	static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0, 0.268161495459, 0.668918986169, 
-												  0.0, 0.268161495459, 0.668918986169, 0.0},
-												  {0.641092593747, 0.0, 0.8373230903, 0.641092593747,
-												  0.0, 0.8373230903, 0.641092593747, 0.0}};
+	static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0,
+                                                0.268161495459, 0.668918986169, 
+												                        0.0, 0.268161495459,
+                                                0.668918986169, 0.0},
+												                       {0.641092593747, 0.0,
+                                                0.8373230903, 0.641092593747,
+                                                0.0, 0.8373230903,
+                                                0.641092593747, 0.0}};
 
-	if( data <= -500) return 0;
+	if( data <= -500) {
+    return 0;
+  }
 
-	if(modifier == "SHAPE_AC" || modifier == "SHAPE_GU") 
-	{
+	if(modifier == "SHAPE_AC" || modifier == "SHAPE_GU") {
 		// This is only applied if SHAPE_AC or SHAPE_GU is specified
 		// For now, I'm using the "default" calculations for SHAPE
 		// pseudoenergies when the modifier is "SHAPE".
 		params = SHAPE_params;
-	} 
-
-	else if (modifier == "DMS") params = DMS_params;
-	else if (modifier == "CMCT") params = CMCT_params;
-	else if (modifier == "diffSHAPE") 
-	{
-		if (data > 0) return data * slope;
-		else return 0;
+	} else if (modifier == "DMS") {
+    params = DMS_params;
+  } else if (modifier == "CMCT") {
+    params = CMCT_params;
+  } else if (modifier == "diffSHAPE") {
+		if (data > 0) {
+      return data * slope;
+    } else {
+      return 0;
+    }
+	} else {
+		if (data > 0) {
+      return log(data + 1.0) * slope + intercept;
+    } else {
+      return intercept;
+    }
 	}
-	else
-	{
-		if (data > 0) return log(data + 1.0) * slope + intercept;
-		else return intercept;
-	}
 
-	if (data < 0 || (slope == 0 && intercept == 0)) return 0;
+	if (data < 0 || (slope == 0 && intercept == 0)) {
+    return 0;
+  }
 	//double val2 = log(data+1.0)*slope+intercept;
 	double kT = 5.904976983149999;
 	double val = Potential(data, params, kT);
 
-	//if(slope == 0 && intercept == 0) return 0; redudant (already checked one if statement above)
 	return val;
 }
 
-//END STOLEN FROM RNASTRUCTURE
-inline double calculateScore(const Subsequence &Base, const bool isUnpaired, const std::vector<double>& probingData, const double clusterPaired, const double clusterUnpaired, const std::string& modifier)
-{
-	double score = 0.0;
-
-  	for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++)
-	{
-		if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) continue;
-    	if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) continue;
-
-		if (strcmp(getProbing_normalization(), "centroid") == 0)
-		{
-			if (isUnpaired) score += fabs(probingData[i] - clusterUnpaired);
-			else score += fabs(probingData[i] - clusterPaired);
-		} 
-		else
-		{
-			if (isUnpaired) score += probingData[i];
-			else score -= probingData[i];
-		}
-	}
-	return score;
+// END STOLEN FROM RNASTRUCTURE
+inline double calculateScore(const Subsequence &Base, const bool isUnpaired,
+                             const std::vector<double> &probingData,
+                             const double clusterPaired,
+                             const double clusterUnpaired,
+                             const std::string &modifier) {
+  double score = 0.0;
+  for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++) {
+    if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) {
+      continue;
+    }
+    if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) {
+      continue;
+    }
+    if (strcmp(getProbing_normalization(), "centroid") == 0) {
+      if (isUnpaired) {
+        score += fabs(probingData.at(i) - clusterUnpaired);
+      } else {
+        score += fabs(probingData.at(i) - clusterPaired);
+      }
+    } else {
+      if (isUnpaired) {
+        score += probingData.at(i);
+      } else {
+        score -= probingData.at(i);
+      }
+    }
+  }
+  return score;
 }
 
-#ifdef HASHLOOKUP
-
-#include <unordered_map>
-#include <boost/functional/hash.hpp>
-
-inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset)
-{
-	static int callCounter = 0;
-	static int couldSkipCounter = 0;
-	static std::unordered_map<std::size_t, double> iSubseqScores; // store previously calculated scores in here
-	static std::unordered_map<std::size_t, double> oSubseqScores; // store previously calculated scores in here
-
-	static bool isLoaded = false;
-  	static std::vector<double> off_probingData;
-  	static std::vector<double> probingData;
-	static double clusterUnpaired;
-	static double clusterPaired;
-
-	std::string modifier = getProbing_modifier();
-	int sep = -1;
-	double score;
-
-	callCounter++;
-
-	// incrementally constuct a unique key/hash from the function parameters
-	std::size_t iKey = 0;
-	std::size_t oKey = 0;
-
-	// build hash for inputSubSeq scores
-	boost::hash_combine(iKey, inputSubseq.i); // i and j positions of Subsequence object uniquely identify it
-	boost::hash_combine(iKey, inputSubseq.j);
-	boost::hash_combine(iKey, isUnpaired);
-
-	// build hash for offsetSubSeq scores
-	boost::hash_combine(oKey, offsetSubseq.i);
-	boost::hash_combine(oKey, offsetSubseq.j);
-	boost::hash_combine(oKey, isUnpaired);
-  
-	if (!isLoaded) {
-		std::string line;
-		std::ifstream infile (getProbing_dataFilename());
-		if (infile.is_open()) 
-		{
-			while (getline (infile,line)) {
-				char *thisLine = strdup(line.c_str());
-				//we expect each line to hold the base position (starting with 1) and the reactivity.
-				if (strcmp(thisLine,"&")==0){
-					sep = probingData.size();
-					continue;
-				}
-				strtok(thisLine, " \t");
-				double reactivity = atof(strtok(NULL, " \t"));	
-				probingData.push_back(reactivity);
-			}
-			infile.close();
-		}
-			
-		// TODO (kmaibach): needs reworking when changing the way the whitespace between two sequences is represented
-		unsigned int inputsLength = 0;
-		std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
-					
-		if (offset) {
-		inputsLength = inputsSequences[0].second + inputsSequences[1].second;
-		} 
-		else {
-		inputsLength = inputsSequences[0].second;
-		}
-		
-		if (probingData.size() < inputsLength) {
-		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' misses " << (inputsLength - probingData.size()) << " data-row(s) " << std::endl << "         compared to the number of nucleotides in your input sequence." << std::endl << "         Missing values will be set to 0.0!" << std::endl;
-		}
-		if (probingData.size() > inputsLength) {
-		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' contains " << (probingData.size()-inputsLength) << " more row(s) " << std::endl << "         than there are nucleotides in your input sequence." << std::endl << "         Exceeding data lines will be ignored!" << std::endl;	
-		}
-			
-		// centroid normalization
-		if (strcmp(getProbing_normalization(), "centroid") == 0) {		
-			int numData = probingData.size();
-			Subsequence base = inputSubseq;
-			double *data = new double[numData];
-			int i = 0;
-			int j = 0;
-			int k;
-			for (i = 0; i < numData; i++) {
-				k = i;
-				if (offset && (i >= (int) inputsSequences[0].second || i >= sep))
-				{ 
-					base = offsetSubseq;
-					k = i - sep;
-				
-				}
-				if ((modifier == "DMS") && (base[k] != A_BASE) && (base[k] != C_BASE)) {
-					continue;
-				}
-				if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
-					continue;
-				}
-				if (probingData[i] < 0) {
-					data[j] = 0.0;
-					probingData[i] = 0.0;
-				} 
-				else {
-					data[j] = probingData[i];
-				}
-			j++;
-			}
-
-			double centroids[2];
-			kmeans(2, j, data, centroids);
-			clusterUnpaired = centroids[0];
-			clusterPaired = centroids[1];
-			delete[] data;
-		}
-		
-		if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				*it = CalculatePseudoEnergy(*it,modifier,getProbing_slope(),getProbing_intercept()); //the parameters are: plain reactivity, modifier type, slope, intercept
-			}
-		}
-		if (strcmp(getProbing_normalization(), "logplain") == 0) {
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				if (*it+1.0 < 0.0) {
-					*it = 0.0;
-				} 
-				else {
-					*it = log(*it+1.0);
-				}
-			}
-		}
-		if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
-			double max = 0.0;
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				if (max < *it) max = *it;
-				if (*it < 0.0) *it = 0.0;
-			}
-			if (max > 0.0) {
-				for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-					*it = ((int) ((*it / max) * 10.0)) / 10.0;
-				}
-			}
-		}
-			
-		if (sep > -1)
-		{
-			off_probingData = std::vector<double>(probingData.rbegin(), probingData.rend());
-			probingData.clear();
-		}
-
-		isLoaded = true;
-	}
-	
-	// check if inputSubseq score was already computed once before
-	if (iSubseqScores.find(iKey) != iSubseqScores.end())
-	{
-		score = iSubseqScores[iKey];
-	}
-	else
-	{
-		double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData, 
-		                                     clusterPaired, clusterUnpaired, modifier);
-		score = iSubseqScore;
-		iSubseqScores[iKey] = iSubseqScore;
-
-	}
-	
-	// check if offsetSubseq score was already computed once before
-	if (offset) 
-	{
-		if (oSubseqScores.find(oKey) != oSubseqScores.end())
-		{
-			score += oSubseqScores[oKey];
-		}
-		else
-		{
-			double offsetSubseqScore = calculateScore(offsetSubseq, isUnpaired, off_probingData, 
-			                                          clusterPaired, clusterUnpaired, modifier);
-			score += offsetSubseqScore;
-			oSubseqScores[oKey] = offsetSubseqScore;
-		}
-	}
-
-	#ifdef PRINT_INFO
-	// print a bunch of (debugging) information
-	if (callCounter % 50000 == 0)
-	{
-		std::cout << "Called getReactivityScore " << callCounter << " times. Could return early " << couldSkipCounter << " times." << std::endl;
-
-		printf("Generated hash: %ld, Func Params: Seq1: %d, %d; Seq2: %d, %d, isUnpaired: %d, offset: %d\n", key, inputSubseq.i, inputSubseq.j, offsetSubseq.i, offsetSubseq.j, isUnpaired, offset);
-		printf("Seq1: ");
-		for (int i=inputSubseq.i; i<inputSubseq.j; i++) 
-		{
-			if (inputSubseq[i] == A_BASE) printf("A");
-			else if (inputSubseq[i] == G_BASE) printf("G");
-			else if (inputSubseq[i] == C_BASE) printf("C");
-			else if (inputSubseq[i] == U_BASE) printf("U");
-		}
-
-		printf("\nSeq2: ");
-		for (int i=offsetSubseq.i; i<offsetSubseq.j; i++) 
-		{
-			if (offsetSubseq[i] == A_BASE) printf("A");
-			else if (offsetSubseq[i] == G_BASE) printf("G");
-			else if (offsetSubseq[i] == C_BASE) printf("C");
-			else if (offsetSubseq[i] == U_BASE) printf("U");
-		}
-		printf("\nScore: %f\n\n", score);
-	}
-	#endif
-
-	return score;
-}
-#elif defined(ARRAYLOOKUP)
-
-#ifdef PRECALC
-inline double calculateScoreAdj(const unsigned int Base_i, const unsigned int Base_j, const Subsequence &Base,
-                                const unsigned int isUnpaired, const std::vector<double>& probingData, 
-								const double clusterPaired, const double clusterUnpaired, const std::string& modifier)
-{
-	double score = 0.0;
-
-  	for (unsigned int i = Base_i; i < Base_j && i < probingData.size(); i++)
-	{
-		if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) continue;
-    	if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) continue;
-
-		if (strcmp(getProbing_normalization(), "centroid") == 0)
-		{
-			if (isUnpaired) score += fabs(probingData[i] - clusterUnpaired);
-			else score += fabs(probingData[i] - clusterPaired);
-		} 
-		else
-		{
-			if (isUnpaired) score += probingData[i];
-			else score -= probingData[i];
-		}
-	}
-
-	return score;
-}
-#endif
-
-inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset) {
-	static bool isLoaded = false;
-	static std::vector<double> off_probingData;
-	static std::vector<double> probingData;
-
-	static unsigned int iLen = inputSubseq.seq->n;
-	static unsigned int oLen = offsetSubseq.seq->n;
-
-	#ifdef TRIU_ONLY
-	/*
-	  -store only the upper triangular matrix (as a 1d array)
-	  -makes figuring out the correct indices a bit more
-	   complicated and adds slightly more compute
-	  -roughly cuts the required memory in half
-	*/
-
-	static unsigned int iTriuSum = (iLen*(iLen+1)) / 2;
-	static unsigned int oTriuSum = (oLen*(oLen+1)) / 2;
-	
-	unsigned int currI_TrilSum = (inputSubseq.i * (inputSubseq.i + 1)) / 2;
-	unsigned int currO_TrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
-
-	unsigned long iIndex = (iTriuSum * isUnpaired) + inputSubseq.i * iLen + inputSubseq.j - currI_TrilSum;
-	unsigned long oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen + offsetSubseq.j - currO_TrilSum;
-
-	static double* iSubseqScores = new double[iTriuSum*2]();
-
-	// only allocate array for offset Subseq scores if offset is true
-	static double* oSubseqScores = offset ? new double[oTriuSum*2]() : iSubseqScores;
-
-	#else
-	/*
-	  allocate n*n matrix as single dimensional array and initialize values to 0
-	  -makes indexing easier
-	  -requires roughly twice the amount of memory as using only the upper triangular matrix
-	*/
-
-	unsigned long iIndex = (iLen * iLen * isUnpaired) + inputSubseq.i * iLen + inputSubseq.j;
-	unsigned long oIndex = (oLen * oLen * isUnpaired) + offsetSubseq.i * oLen + offsetSubseq.j;
-
-	static double* iSubseqScores = new double[iLen*iLen*2]();
-	
-	// only allocate array for offset Subseq scores if offset is true
-	static double* oSubseqScores = offset ? new double[oLen*oLen*2]() : iSubseqScores;
-	#endif
-
-	int sep = -1;
-	double score;
-
-	static double clusterUnpaired;
-	static double clusterPaired;
-	std::string modifier = getProbing_modifier();
-	
-	if (!isLoaded) 
-	{
-		std::string line;
-		std::ifstream infile (getProbing_dataFilename());
-		if (infile.is_open()) 
-		{
-			while (getline (infile,line)) {
-				char *thisLine = strdup(line.c_str());
-				//we expect each line to hold the base position (starting with 1) and the reactivity.
-				if (strcmp(thisLine,"&")==0){
-					sep = probingData.size();
-					continue;
-				}
-				strtok(thisLine, " \t");
-				double reactivity = atof(strtok(NULL, " \t"));	
-				probingData.push_back(reactivity);
-			}
-			infile.close();
-		}
-			
-		// TODO (kmaibach): needs reworking when changing the way the whitespace between two sequences is represented
-		unsigned int inputsLength = 0;
-		std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
-					
-		if (offset) {
-		inputsLength = inputsSequences[0].second + inputsSequences[1].second;
-		} 
-		else {
-		inputsLength = inputsSequences[0].second;
-		}
-		
-		if (probingData.size() < inputsLength) {
-		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' misses " << (inputsLength - probingData.size()) << " data-row(s) " << std::endl << "         compared to the number of nucleotides in your input sequence." << std::endl << "         Missing values will be set to 0.0!" << std::endl;
-		}
-		if (probingData.size() > inputsLength) {
-		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' contains " << (probingData.size()-inputsLength) << " more row(s) " << std::endl << "         than there are nucleotides in your input sequence." << std::endl << "         Exceeding data lines will be ignored!" << std::endl;	
-		}
-			
-		// centroid normalization
-		if (strcmp(getProbing_normalization(), "centroid") == 0) 
-		{		
-			int numData = probingData.size();
-			Subsequence base = inputSubseq;
-			double *data = new double[numData];
-			int i = 0;
-			int j = 0;
-			int k;
-			for (i = 0; i < numData; i++)
-			{
-				k = i;
-				if (offset && (i >= (int) inputsSequences[0].second || i >= sep))
-				{ 
-					base = offsetSubseq;
-					k = i - sep;
-				
-				}
-				if ((modifier == "DMS") && (base[k] != A_BASE) && (base[k] != C_BASE)) {
-					continue;
-				}
-				if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
-					continue;
-				}
-				if (probingData[i] < 0) {
-					data[j] = 0.0;
-					probingData[i] = 0.0;
-				} 
-				else {
-					data[j] = probingData[i];
-				}
-				j++;
-			}
-
-			double centroids[2];
-			kmeans(2, j, data, centroids);
-			clusterUnpaired = centroids[0];
-			clusterPaired = centroids[1];
-			delete[] data;
-		}
-	
-		if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				*it = CalculatePseudoEnergy(*it,modifier,getProbing_slope(),getProbing_intercept()); //the parameters are: plain reactivity, modifier type, slope, intercept
-			}
-		}
-		if (strcmp(getProbing_normalization(), "logplain") == 0) {
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				if (*it+1.0 < 0.0) {
-					*it = 0.0;
-				} 
-				else {
-					*it = log(*it+1.0);
-				}
-			}
-		}
-		if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
-			double max = 0.0;
-			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				if (max < *it) max = *it;
-				if (*it < 0.0) *it = 0.0;
-			}
-			if (max > 0.0) {
-				for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-					*it = ((int) ((*it / max) * 10.0)) / 10.0;
-				}
-			}
-		}
-		
-		if (sep > -1)
-		{
-			off_probingData = std::vector<double>(probingData.rbegin(), probingData.rend());
-			probingData.clear();
-		}
-
-		isLoaded = true;
-
-		#ifdef PRECALC
-		for (unsigned int unpaired=0; unpaired<2; unpaired++)
-		{
-			for (unsigned int i=0; i<iLen-1; i++)
-			{
-				for (unsigned int j=i+1; j<iLen; j++) 
-				{
-					#ifdef TRIU_ONLY
-					unsigned int currI_TrilSum = (i * (i + 1)) / 2;
-					unsigned long iIndex = (iTriuSum * unpaired) + i * iLen + j - currI_TrilSum;
-					#else
-					unsigned long iIndex = (iLen * iLen * unpaired) + i * iLen + j;
-					#endif
-					iSubseqScores[iIndex] = calculateScoreAdj(i, j, inputSubseq, unpaired, probingData, clusterPaired, clusterUnpaired, modifier);
-				}
-			}
-		}
-
-		if (offset)
-		{
-			for (unsigned int unpaired=0; unpaired<2; unpaired++)
-			{
-				for (unsigned int i=0; i<oLen-1; i++)
-				{
-					for (unsigned int j=i+1; j<oLen; j++)
-					{
-						#ifdef TRIU_ONLY
-						unsigned int currO_TrilSum = (i * (i + 1)) / 2;
-						unsigned long oIndex = (oTriuSum * unpaired) + i * oLen + j - currO_TrilSum;
-						#else
-						unsigned long oIndex = (oLen * oLen * unpaired) + i * oLen + j;
-						#endif
-						oSubseqScores[oIndex] = calculateScoreAdj(i, j, offsetSubseq, unpaired, off_probingData, clusterPaired, clusterUnpaired, modifier);
-					}
-				}
-			}
-		}
-		#endif
-	}
-	
-	#ifdef PRECALC
-	score = iSubseqScores[iIndex];
-	if (offset) score += oSubseqScores[oIndex];
-	
-	#else
-	if (iSubseqScores[iIndex]) // check if score was already calculated once (meaning if value at index isn't 0 anymore)
-	{
-		score = iSubseqScores[iIndex];
-	}
-	else
-	{
-		double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
-		score = iSubseqScore;
-		iSubseqScores[iIndex] = iSubseqScore;
-	}
-
-	if (offset)
-	{
-		if (oSubseqScores[oIndex])
-		{
-			score += oSubseqScores[oIndex];
-		}
-		else
-		{
-			double oSubseqScore = calculateScore(offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier);
-			score += oSubseqScore;
-			oSubseqScores[oIndex] = oSubseqScore;
-		}
-	}
-	#endif
-
-	return score;
-}
-
-#else
-inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset) {
+inline double getReactivityScore(const Subsequence &inputSubseq,
+                                 const bool isUnpaired,
+                                 const Subsequence &offsetSubseq,
+                                 const bool offset) {
   static bool isLoaded = false;
   static std::vector<double> off_probingData;
   static std::vector<double> probingData;
-    
+
   int sep = -1;
   double score;
 
   static double clusterUnpaired;
   static double clusterPaired;
   std::string modifier = getProbing_modifier();
-  
+
+	/*
+    -store scores in a lookup matrix to avoid recalculations
+	  -store only the upper triangular matrix (as a 1d-array)
+	   ->makes figuring out the correct indices a bit more
+	     complicated and adds slightly more compute compared
+       to using a NxN array, but roughly cuts the required memory in half
+	*/
+
+  static unsigned int iLen = inputSubseq.seq->n; // length of inputSubseq
+	static unsigned int oLen = offsetSubseq.seq->n; // length of offsetSubseq
+
+	static unsigned int iTriuSum = (iLen * (iLen + 1)) / 2;
+	static unsigned int oTriuSum = (oLen * (oLen + 1)) / 2;
+	
+  /*
+    -calculate sums of the size/number of cells in the lower triangular
+     up to row inputSubseq.i/offsetSubseq.i based on the
+     current inputSubseq/offsetSubseq input parameters
+    -these are needed to calculate the correct index in the
+     1d array representing the upper triangular matrix
+     containing all previously calculated scores
+  */
+	unsigned int ciTrilSum = (inputSubseq.i * (inputSubseq.i + 1)) / 2;
+	unsigned int coTrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
+
+  // calculate the correct indices for the score lookup/storing
+	unsigned int iIndex = (iTriuSum * isUnpaired) + inputSubseq.i * iLen +
+                        inputSubseq.j - ciTrilSum;
+	unsigned int oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen +
+                        offsetSubseq.j - coTrilSum;
+
+  /*
+    -allocate a static 1d-array (size of upper triangular matrix only)
+     to store/look up the scores
+    -requires additional dimension to store both paired and unpaired scores
+  */
+	static double* iSubseqScores = new double[iTriuSum*2](); 
+
+	// only allocate array for offset Subseq scores if offset is true
+	static double* oSubseqScores = offset ? new double[oTriuSum*2]() :
+                                 iSubseqScores;
+
+
   if (!isLoaded) {
-	  std::string line;
-	  std::ifstream infile (getProbing_dataFilename());
-	  if (infile.is_open()) {
-		  while (getline (infile,line)) {
-			  char *thisLine = strdup(line.c_str());
-			  //we expect each line to hold the base position (starting with 1) and the reactivity.
-			  if (strcmp(thisLine,"&")==0){
-			    sep = probingData.size();
-					continue;
-			  }
-			  strtok(thisLine, " \t");
-		    double reactivity = atof(strtok(NULL, " \t"));	
-		    probingData.push_back(reactivity);
-		  }
-		  infile.close();
+    std::string line;
+    std::ifstream infile(getProbing_dataFilename());
+    if (infile.is_open()) {
+      while (getline(infile, line)) {
+        char *thisLine = strdup(line.c_str());
+        /* we expect each line to hold the base position (starting with 1) and
+           the reactivity. */
+        if (strcmp(thisLine, "&") == 0) {
+          sep = probingData.size();
+          continue;
+        }
+        strtok(thisLine, " \t");
+        double reactivity = atof(strtok(NULL, " \t"));
+        probingData.push_back(reactivity);
+      }
+      infile.close();
     }
-        
-    // TODO (kmaibach): needs reworking when changing the way the whitespace between two sequences is represented
+
+    /* TODO (kmaibach): needs reworking when changing the way the whitespace
+       between two sequences is represented */
     unsigned int inputsLength = 0;
-    std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
-                
+    std::vector<std::pair<const char*, unsigned> > inputsSequences = \
+      getInputs();
+
     if (offset) {
-      inputsLength = inputsSequences[0].second + inputsSequences[1].second;
+      inputsLength = inputsSequences.at(0).second + \
+                     inputsSequences.at(1).second;
     } else {
-      inputsLength = inputsSequences[0].second;
+      inputsLength = inputsSequences.at(0).second;
     }
-       
+
     if (probingData.size() < inputsLength) {
-      std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' misses " << (inputsLength - probingData.size()) << " data-row(s) " << std::endl << "         compared to the number of nucleotides in your input sequence." << std::endl << "         Missing values will be set to 0.0!" << std::endl;
+      std::cerr << "Warning: chemical probing data file '"
+                << getProbing_dataFilename() << "' misses "
+                << (inputsLength - probingData.size()) << " data-row(s) "
+                << std::endl << "         compared to the number of nucleotides"
+                << " in your input sequence." << std::endl
+                << "         Missing values will be set to 0.0!" << std::endl;
     }
     if (probingData.size() > inputsLength) {
-      std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' contains " << (probingData.size()-inputsLength) << " more row(s) " << std::endl << "         than there are nucleotides in your input sequence." << std::endl << "         Exceeding data lines will be ignored!" << std::endl;	
+      std::cerr << "Warning: chemical probing data file '"
+                << getProbing_dataFilename() << "' contains "
+                << (probingData.size()-inputsLength) << " more row(s) "
+                << std::endl << "         than there are nucleotides in your "
+                << "input sequence." << std::endl
+                << "         Exceeding data lines will be ignored!"
+                << std::endl;
     }
-        
+
     // centroid normalization
-	  if (strcmp(getProbing_normalization(), "centroid") == 0) {		
+    if (strcmp(getProbing_normalization(), "centroid") == 0) {
       int numData = probingData.size();
-	    Subsequence base = inputSubseq;
-	    double *data = (double *) malloc(sizeof(double) * numData);
-	    int i = 0;
-	    int j = 0;
-	    int k;
-	    for (i = 0; i < numData; i++) {
-		    k = i;
-		    if (offset) {
-		      if(i >= (int) inputsSequences[0].second || i >= sep) {
-				    base = offsetSubseq;
-					  k = i - sep;
-			    }
-			  }
-			  if ((modifier == "DMS") && (base[k] != A_BASE) && (base[k] != C_BASE)) {
-			    continue;
-			  }
-			  if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
-			    continue;
-			  }
-			  if (probingData[i] < 0) {
-			    data[j] = 0.0;
-				  probingData[i] = 0.0;
-			  } else {
-				  data[j] = probingData[i];
-			  }
+      Subsequence base = inputSubseq;
+      double *data = static_cast<double *>(
+        malloc(sizeof(double) * numData));
+      int i = 0;
+      int j = 0;
+      int k;
+      for (i = 0; i < numData; i++) {
+        k = i;
+        if (offset) {
+          if (i >= static_cast<int>(inputsSequences.at(0).second)
+              || i >= sep) {
+            base = offsetSubseq;
+            k = i - sep;
+          }
+        }
+        if ((modifier == "DMS") && (base[k] != A_BASE) &&
+            (base[k] != C_BASE)) {
+          continue;
+        }
+        if ((modifier == "CMCT") && (base[k] != U_BASE) &&
+            (base[k] != G_BASE)) {
+          continue;
+        }
+        if (probingData.at(i) < 0) {
+          data[j] = 0.0;
+          probingData.at(i) = 0.0;
+        } else {
+          data[j] = probingData.at(i);
+        }
         j++;
       }
-      double *centroids = (double *) malloc(sizeof(double) * 2);
-      kmeans(2,j,data,centroids);
+      double *centroids = static_cast<double *>(
+        malloc(sizeof(double) * 2));
+      kmeans(2, j, data, centroids);
       clusterUnpaired = centroids[0];
       clusterPaired = centroids[1];
-	  free(data);
-	  free(centroids);
+      free(data);
+      free(centroids);
     }
-    
-	  if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-	    for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-		    *it = CalculatePseudoEnergy(*it,modifier,getProbing_slope(),getProbing_intercept()); //the parameters are: plain reactivity, modifier type, slope, intercept
-		  }
-	  }
-	  if (strcmp(getProbing_normalization(), "logplain") == 0) {
-		  for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-			  if (*it+1.0 < 0.0) {
-				  *it = 0.0;
-			  } else {
-				  *it = log(*it+1.0);
-			  }
-		  }
-	  }
-	  if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
-		  double max = 0.0;
-		  for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-			  if (max < *it) max = *it;
-			  if (*it < 0.0) *it = 0.0;
-		  }
-		  if (max > 0.0) {
-			  for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
-				  *it = ((int) ((*it / max) * 10.0)) / 10.0;
-			  }
-		  }
-	  }
-        
-	  if (sep > -1){
-		  for (int i=probingData.size()-1; i>=sep; i--){
-			  off_probingData.insert(off_probingData.begin(), probingData[i]);
-			  probingData.erase(probingData.begin() + i);
-		  }
-	  }
-	  isLoaded = true;
+
+    if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
+      for (std::vector<double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        // the parameters are: plain reactivity, modifier type, slope, intercept
+        *it = CalculatePseudoEnergy(*it, modifier, getProbing_slope(),
+                                    getProbing_intercept());
+      }
+    }
+    if (strcmp(getProbing_normalization(), "logplain") == 0) {
+      for (std::vector<double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        if (*it+1.0 < 0.0) {
+          *it = 0.0;
+        } else {
+          *it = log(*it+1.0);
+        }
+      }
+    }
+    if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
+      double max = 0.0;
+      for (std::vector<double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        if (max < *it) max = *it;
+        if (*it < 0.0) *it = 0.0;
+      }
+      if (max > 0.0) {
+        for (std::vector<double>::iterator it = probingData.begin();
+            it != probingData.end(); it++) {
+          *it = static_cast<int>(((*it / max) * 10.0)) / 10.0;
+        }
+      }
+    }
+
+    if (sep > -1) {
+      for (int i=probingData.size()-1; i >= sep; i--) {
+        off_probingData.insert(off_probingData.begin(), probingData.at(i));
+        probingData.erase(probingData.begin() + i);
+      }
+    }
+    isLoaded = true;
   }
-   
-	if (offset) {
-		score = calculateScore(offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier) + calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
-	}	else {
-	  score = calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+
+  /*
+    -check if score was already calculated once
+     (meaning if value at index isn't 0 anymore)
+    -if so, simply use that score instead of recalculating
+    -if it doesn't exist yet, calculate it and store it in
+     the lookup array
+  */
+	if (iSubseqScores[iIndex]) {
+		score = iSubseqScores[iIndex];
+	} else {
+		double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData,
+                                         clusterPaired, clusterUnpaired,
+                                         modifier);
+		score = iSubseqScore;
+		iSubseqScores[iIndex] = iSubseqScore;
 	}
-	return score;
+
+  // if offset is true, do the same thing
+	if (offset) {
+		if (oSubseqScores[oIndex]) {
+			score += oSubseqScores[oIndex];
+		} else {
+			double oSubseqScore = calculateScore(offsetSubseq, isUnpaired,
+                                           off_probingData, clusterPaired,
+                                           clusterUnpaired, modifier);
+			score += oSubseqScore;
+			oSubseqScores[oIndex] = oSubseqScore;
+		}
+	}
+
+  return score;
 }
-#endif
 
 // two track
-inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq) {
+inline double getReactivityScore(const Subsequence &inputSubseq,
+                                 const bool isUnpaired,
+                                 const Subsequence &offsetSubseq) {
   return(getReactivityScore(inputSubseq, isUnpaired, offsetSubseq, true));
 }
 
 // single track
-inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired) {
+inline double getReactivityScore(const Subsequence &inputSubseq,
+                                 const bool isUnpaired) {
   return(getReactivityScore(inputSubseq, isUnpaired, inputSubseq, false));
 }
 
 #endif
-
-

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -159,72 +159,71 @@ inline double Potential(double data, const double (*params)[8],
    reactivity distribution per modifier, or the "classic" Deigan et al. bonus
    term when no modifier or an unrecognized modifier is provided. */
 
-inline double CalculatePseudoEnergy(double data, std::string &modifier,
-                                    double slope, double intercept) 
-{
- static const double (*params)[8];
- static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
-                                                0.0830320205572, 0.0,
-                                                0.0830320205572,
-                                                1.82374892807, 0.0}, 
-                                               {1.27932240423, 0.0,
-                                                0.374470347084, 1.27932240423,
-                                                0.0, 0.374470347084,
-                                                1.27932240423, 0.0}};
+inline double CalculatePseudoEnergy(double data, const std::string &modifier,
+                                    double slope, double intercept) {
+  static const double (*params)[8];
+  static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
+                                                 0.0830320205572, 0.0,
+                                                 0.0830320205572,
+                                                 1.82374892807, 0.0},
+                                                {1.27932240423, 0.0,
+                                                 0.374470347084, 1.27932240423,
+                                                 0.0, 0.374470347084,
+                                                 1.27932240423, 0.0}};
 
- static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0,
+  static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0,
                                                0.0876565404957, 1.36184674022,
                                                0.0, 0.0876565404957,
                                                1.36184674022, 0.0},
-                                             {1.33486621438, 0.0,
+                                              {1.33486621438, 0.0,
                                                0.37015874678, 1.33486621438,
                                                0.0, 0.37015874678,
                                                1.33486621438, 0.0}};
 
- static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0,
-                                               0.268161495459, 0.668918986169, 
-                                               0.0, 0.268161495459,
-                                               0.668918986169, 0.0},
-                                              {0.641092593747, 0.0,
-                                               0.8373230903, 0.641092593747,
-                                               0.0, 0.8373230903,
-                                               0.641092593747, 0.0}};
+  static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0,
+                                                0.268161495459, 0.668918986169,
+                                                0.0, 0.268161495459,
+                                                0.668918986169, 0.0},
+                                               {0.641092593747, 0.0,
+                                                0.8373230903, 0.641092593747,
+                                                0.0, 0.8373230903,
+                                                0.641092593747, 0.0}};
 
- if( data <= -500) {
+  if (data <= -500) {
     return 0;
   }
 
- if(modifier == "SHAPE_AC" || modifier == "SHAPE_GU") {
-  // This is only applied if SHAPE_AC or SHAPE_GU is specified
-  // For now, I'm using the "default" calculations for SHAPE
-  // pseudoenergies when the modifier is "SHAPE".
-  params = SHAPE_params;
- } else if (modifier == "DMS") {
+  if (modifier == "SHAPE_AC" || modifier == "SHAPE_GU") {
+    // This is only applied if SHAPE_AC or SHAPE_GU is specified
+    // For now, I'm using the "default" calculations for SHAPE
+    // pseudoenergies when the modifier is "SHAPE".
+    params = SHAPE_params;
+  } else if (modifier == "DMS") {
     params = DMS_params;
   } else if (modifier == "CMCT") {
     params = CMCT_params;
   } else if (modifier == "diffSHAPE") {
-  if (data > 0) {
+    if (data > 0) {
       return data * slope;
     } else {
       return 0;
     }
- } else {
-  if (data > 0) {
+  } else {
+    if (data > 0) {
       return log(data + 1.0) * slope + intercept;
     } else {
       return intercept;
     }
- }
+  }
 
- if (data < 0 || (slope == 0 && intercept == 0)) {
+  if (data < 0 || (slope == 0 && intercept == 0)) {
     return 0;
   }
- //double val2 = log(data+1.0)*slope+intercept;
- double kT = 5.904976983149999;
- double val = Potential(data, params, kT);
+  // double val2 = log(data+1.0)*slope+intercept;
+  double kT = 5.904976983149999;
+  double val = Potential(data, params, kT);
 
- return val;
+  return val;
 }
 
 // END STOLEN FROM RNASTRUCTURE
@@ -279,12 +278,12 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
        complicated and adds slightly more compute compared
        to using a NxN array, but roughly cuts the required memory in half */
 
-  static unsigned int iLen = inputSubseq.seq->n; // length of inputSubseq
-  static unsigned int oLen = offsetSubseq.seq->n; // length of offsetSubseq
+  static unsigned int iLen = inputSubseq.seq->n;   // length of inputSubseq
+  static unsigned int oLen = offsetSubseq.seq->n;  // length of offsetSubseq
 
   static unsigned int iTriuSum = (iLen * (iLen + 1)) / 2;
   static unsigned int oTriuSum = (oLen * (oLen + 1)) / 2;
- 
+
   /* -calculate sums of the size/number of cells in the lower triangular
       up to row inputSubseq.i/offsetSubseq.i based on the
       current inputSubseq/offsetSubseq input parameters
@@ -304,12 +303,12 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
   /* -allocate a static 1d-array (size of upper triangular matrix only)
       to store/look up the scores
      -requires additional dimension to store both paired and unpaired scores */
-  static double* iSubseqScores = new double[iTriuSum*2](); 
+  static double* iSubseqScores = new double[iTriuSum*2]();
 
   // only allocate array for offset Subseq scores if offset is true
   static double* oSubseqScores = offset ? new double[oTriuSum*2]() :
                                  iSubseqScores;
-                                 
+
   if (!isLoaded) {
     std::string line;
     std::ifstream infile(getProbing_dataFilename());
@@ -445,13 +444,12 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
     isLoaded = true;
   }
 
-  /*
-    -check if score was already calculated once
+  /* -check if score was already calculated once
      (meaning if value at index isn't 0 anymore)
     -if so, simply use that score instead of recalculating
     -if it doesn't exist yet, calculate it and store it in
-     the lookup array
-  */
+     the lookup array */
+
   if (iSubseqScores[iIndex]) {
     score = iSubseqScores[iIndex];
   } else {

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -314,11 +314,6 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
      -requires additional dimension to store both paired and unpaired scores */
   static std::vector<double> iSubseqScores(iTriuSum * 2);
 
-  // only allocate array for offset Subseq scores if offset is true
-  static std::vector<double> oSubseqScores = offset ?
-                                             std::vector<double>(oTriuSum * 2) :
-                                             iSubseqScores;
-
   if (!isLoaded) {
     std::string line;
     std::ifstream infile(getProbing_dataFilename());
@@ -472,6 +467,11 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
 
   // if offset is true, do the same thing
   if (offset) {
+    /* only allocate array for offset Subseq scores if offset is true
+       (in the GAPC compilations that call this function, offset is either
+       always true or always false) */
+    static std::vector<double> oSubseqScores(oTriuSum * 2);
+
     if (oSubseqScores[oIndex]) {
       score += oSubseqScores[oIndex];
     } else {

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -1,10 +1,38 @@
 #ifndef PROBING_HH
 #define PROBING_HH
 
+
+#define FASTER_getReactivityScore // turn on/off to switch between old/new implementation
+//#define PRINT_INFO
+
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <time.h>
+
+/*
+  Fynn's improvements/suggestions:
+
+  -minor adjustments:
+	-replace vector.at(i) w/ vector[i] (faster)
+
+	-kmeans:
+		-allocate centroid-related arrays on stack (if kmeans is never used for clustering of too many clusters)
+
+	-CalculatePseudoEnergy:
+		-convert std::vector(s) to constant stack-allocated arrays
+	
+	-GetReactivityScore:
+		-pass "probingData" vector (and "modifier" string) to calculateScore by reference (makes code about 0.05x- 0.1x faster)
+		-replace reversing of probingData to off_probingData w/ 
+		vector<double> off_probingData(probingData.rbegin(), probingData.rend()); probingData.clear();
+  
+  -major adjustments:
+	-GetReactivityScore:
+		-keep track of already calculated scores by hashing the function parameters and
+	  	performing a simple hashmap lookup to see if the function was aleady called once
+	  	w/ the same parameters; if so, simply return the previously calculated result (makes code about 5x faster)
+*/
 
 //Stefans own 1-dimensional k-means clustering
 inline void kmeans(int numCluster, int numData, double *input, double centroids[]) {
@@ -17,11 +45,11 @@ inline void kmeans(int numCluster, int numData, double *input, double centroids[
 
 	int sumRunIterations = 0;
 	if (numData >= numCluster) {
-		double *clusterSumDistances = (double *) malloc(sizeof(double) * numCluster);
-		double *bestCentroids = (double *) malloc(sizeof(double) * numCluster);
+		double clusterSumDistances[numCluster];
+		double bestCentroids[numCluster];
+		int numClusterMembers[numCluster];
 		double bestVariance = static_cast<double>(HUGE_VAL);
-		int *assignments = (int *) malloc(sizeof(int) * numData);
-		int *numClusterMembers = (int *) malloc(sizeof(int) * numCluster);
+		int *assignments = new int[numData];
 		double minDist_point2cluster = static_cast<double>(HUGE_VAL);
 		int minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
 		double dist_point2cluster = static_cast<double>(HUGE_VAL);
@@ -98,7 +126,10 @@ inline void kmeans(int numCluster, int numData, double *input, double centroids[
 		for (k = 0; k < numCluster; k++) {
 			centroids[k] = bestCentroids[k];
 		}
-	} else {
+
+		delete[] assignments;
+	} 
+	else {
 		for (k = 0; k < numCluster; k++) {
 			centroids[k] = 1 / numCluster * k;
 		}
@@ -122,168 +153,294 @@ inline double Gammadist(double data, double shape, double loc, double scale){
 	return (1/scale)*pow((data - loc)*(1/scale), (shape - 1))*exp(-(1/scale)*(data - loc))/tgamma(shape);
 }
 
-
-inline double Potential(double data, std::vector< std::vector<double> > params, double kT){
+inline double Potential(double data, const double (*params)[8], double kT)
+{
+	std::cout << "calling new Potential function" << std::endl;
 	// params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for shape, loc scale of component 1
 	// j=3,4,5 for shape, loc, scale of component 2 and j=6,7 for weights of components 1 and 2 respectively.
-	double pairedprob = params[0][6]*Gammadist(data, params[0][0], params[0][1], params[0][2]) +
-	                    params[0][7]*Gammadist(data, params[0][3], params[0][4], params[0][5]);
-	double unpairedprob = params[1][6]*Gammadist(data, params[1][0], params[1][1], params[1][2]) +
-	                      params[1][7]*Gammadist(data, params[1][3], params[1][4], params[1][5]);
-	return -kT*log(pairedprob/unpairedprob);
+	double pairedprob = params[0][6] * Gammadist(data, params[0][0], params[0][1], params[0][2]) +
+	                    params[0][7] * Gammadist(data, params[0][3], params[0][4], params[0][5]);
+	double unpairedprob = params[1][6] * Gammadist(data, params[1][0], params[1][1], params[1][2]) +
+	                      params[1][7] * Gammadist(data, params[1][3], params[1][4], params[1][5]);
+
+	return -kT * log(pairedprob / unpairedprob);
 }
 
 // This function calculates the pseudoenergy for a given reactivity data. It changes the calculation
 // depending on the modifier specified, giving either the log-likelihood-ratio of the unpaired/paired
 // probabilities given a reactivity distribution per modifier, or the "classic" Deigan et al. bonus
 // term when no modifier or an unrecognized modifier is provided.
-inline double CalculatePseudoEnergy(double data, std::string modifier, double slope, double intercept) {
-	std::vector< std::vector<double> > params;
-	static std::vector< std::vector<double> > SHAPE_params;
-	static std::vector< std::vector<double> > DMS_params;
-	static std::vector< std::vector<double> > CMCT_params;
+inline double CalculatePseudoEnergy(double data, std::string modifier, double slope, double intercept) 
+{
+	static const double (*params)[8];
+	static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0, 0.0830320205572, 0.0,
+											   0.0830320205572, 1.82374892807, 0.0}, 
+											   {1.27932240423, 0.0, 0.374470347084, 1.27932240423,
+											   0.0, 0.374470347084, 1.27932240423, 0.0}};
 
-	static bool isInit = false;
-	if (isInit == false) {
-//		SHAPE_params = new std::vector< std::vector<double> >();
-		std::vector<double> shape_l_1;// = new std::vector<double>();
-		shape_l_1.push_back(1.82374892807);
-		shape_l_1.push_back(0.0);
-		shape_l_1.push_back(0.0830320205572);
-		shape_l_1.push_back(1.82374892807);
-		shape_l_1.push_back(0.0);
-		shape_l_1.push_back(0.0830320205572);
-		shape_l_1.push_back(1.82374892807);
-		shape_l_1.push_back(0.0);
-		std::vector<double> shape_l_2;// = new std::vector<double>();
-		shape_l_2.push_back(1.27932240423);
-		shape_l_2.push_back(0.0);
-		shape_l_2.push_back(0.374470347084);
-		shape_l_2.push_back(1.27932240423);
-		shape_l_2.push_back(0.0);
-		shape_l_2.push_back(0.374470347084);
-		shape_l_2.push_back(1.27932240423);
-		shape_l_2.push_back(0.0);
-		SHAPE_params.push_back(shape_l_1);
-		SHAPE_params.push_back(shape_l_2);
+	static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0, 0.0876565404957, 1.36184674022,
+												0.0, 0.0876565404957, 1.36184674022, 0.0},
+												{1.33486621438, 0.0, 0.37015874678, 1.33486621438,
+												0.0, 0.37015874678, 1.33486621438, 0.0}};
 
-//		DMS_params = new std::vector< std::vector<double> >();
-		std::vector<double> dms_l_1;// = new std::vector<double>();
-		dms_l_1.push_back(1.36184674022);
-		dms_l_1.push_back(0.0);
-		dms_l_1.push_back(0.0876565404957);
-		dms_l_1.push_back(1.36184674022);
-		dms_l_1.push_back(0.0);
-		dms_l_1.push_back(0.0876565404957);
-		dms_l_1.push_back(1.36184674022);
-		dms_l_1.push_back(0.0);
-		std::vector<double> dms_l_2;// = new std::vector<double>();
-		dms_l_2.push_back(1.33486621438);
-		dms_l_2.push_back(0.0);
-		dms_l_2.push_back(0.37015874678);
-		dms_l_2.push_back(1.33486621438);
-		dms_l_2.push_back(0.0);
-		dms_l_2.push_back(0.37015874678);
-		dms_l_2.push_back(1.33486621438);
-		dms_l_2.push_back(0.0);
-		DMS_params.push_back(dms_l_1);
-		DMS_params.push_back(dms_l_2);
+	static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0, 0.268161495459, 0.668918986169, 
+												  0.0, 0.268161495459, 0.668918986169, 0.0},
+												  {0.641092593747, 0.0, 0.8373230903, 0.641092593747,
+												  0.0, 0.8373230903, 0.641092593747, 0.0}};
 
-//		CMCT_params = new std::vector< std::vector<double> >();
-		std::vector<double> cmct_l_1;// = new std::vector<double>();
-		cmct_l_1.push_back(0.668918986169);
-		cmct_l_1.push_back(0.0);
-		cmct_l_1.push_back(0.268161495459);
-		cmct_l_1.push_back(0.668918986169);
-		cmct_l_1.push_back(0.0);
-		cmct_l_1.push_back(0.268161495459);
-		cmct_l_1.push_back(0.668918986169);
-		cmct_l_1.push_back(0.0);
-		std::vector<double> cmct_l_2;// = new std::vector<double>();
-		cmct_l_2.push_back(0.641092593747);
-		cmct_l_2.push_back(0.0);
-		cmct_l_2.push_back(0.8373230903);
-		cmct_l_2.push_back(0.641092593747);
-		cmct_l_2.push_back(0.0);
-		cmct_l_2.push_back(0.8373230903);
-		cmct_l_2.push_back(0.641092593747);
-		cmct_l_2.push_back(0.0);
-		CMCT_params.push_back(cmct_l_1);
-		CMCT_params.push_back(cmct_l_2);
+	if( data <= -500) return 0;
 
-		isInit = true;
-	}
-
-	if( data <= -500)
-		return 0;
-	if(modifier == "SHAPE_AC" || modifier == "SHAPE_GU") {
+	if(modifier == "SHAPE_AC" || modifier == "SHAPE_GU") 
+	{
 		// This is only applied if SHAPE_AC or SHAPE_GU is specified
 		// For now, I'm using the "default" calculations for SHAPE
 		// pseudoenergies when the modifier is "SHAPE".
 		params = SHAPE_params;
-	} else {
-		if( modifier == "DMS" ) {
-			params = DMS_params;
-		} else {
-			if( modifier == "CMCT") {
-				params = CMCT_params;
-			} else {
-				if (modifier == "diffSHAPE") {
-					if (data>0){
-						return data * slope;
-					} else {
-						return 0;
-					}
-				} else {
-					if (data > 0) {
-						return log( data + 1.0 )*slope + intercept;
-					} else {
-						return intercept;
-					}
-				}
-			}
-		}
+	} 
+
+	else if (modifier == "DMS") params = DMS_params;
+	else if (modifier == "CMCT") params = CMCT_params;
+	else if (modifier == "diffSHAPE") 
+	{
+		if (data > 0) return data * slope;
+		else return 0;
 	}
-	if( data < 0 || (slope == 0 && intercept == 0))
-		return 0;
+	else
+	{
+		if (data > 0) return log(data + 1.0) * slope + intercept;
+		else return intercept;
+	}
+
+	if (data < 0 || (slope == 0 && intercept == 0)) return 0;
 	//double val2 = log(data+1.0)*slope+intercept;
 	double kT = 5.904976983149999;
 	double val = Potential(data, params, kT);
 
-	if( (slope == 0 && intercept == 0) ){
-		return 0;
-	}
-	else{
-		return val;
-	}
-
+	//if(slope == 0 && intercept == 0) return 0; redudant (already checked one if statement above)
+	return val;
 }
+
 //END STOLEN FROM RNASTRUCTURE
-inline double calculateScore(const Subsequence &Base, const bool isUnpaired, const std::vector<double> probingData, const double clusterPaired, const double clusterUnpaired, const std::string modifier){
-  double score = 0.0;
-  for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++) {
-	  if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) {
-		  continue;
-    }
-    if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) {
-		  continue;
-		}
-		if (strcmp(getProbing_normalization(), "centroid") == 0) {
-			if (isUnpaired) {
-				score += fabs(probingData.at(i) - clusterUnpaired);
-			} else {
-				score += fabs(probingData.at(i) - clusterPaired);
-			}
-		} else {
-			if (isUnpaired) {
-				score += probingData.at(i);
-			} else {
-				score -= probingData.at(i);
-			}
+inline double calculateScore(const Subsequence &Base, const bool isUnpaired, const std::vector<double>& probingData, const double clusterPaired, const double clusterUnpaired, const std::string& modifier)
+{
+	double score = 0.0;
+
+  	for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++)
+	{
+		if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) continue;
+    	if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) continue;
+
+		if (strcmp(getProbing_normalization(), "centroid") == 0)
+		{
+			if (isUnpaired) score += fabs(probingData[i] - clusterUnpaired);
+			else score += fabs(probingData[i] - clusterPaired);
+		} 
+		else
+		{
+			if (isUnpaired) score += probingData[i];
+			else score -= probingData[i];
 		}
 	}
 	return score;
 }
+
+#ifdef FASTER_getReactivityScore
+
+#include <unordered_map>
+#include <boost/functional/hash.hpp>
+
+inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset)
+{
+	static int callCounter = 0;
+	static int couldSkipCounter = 0;
+	static std::unordered_map<std::size_t, double> prevScores; // store previously calculated scores in here
+
+	static bool isLoaded = false;
+  	static std::vector<double> off_probingData;
+  	static std::vector<double> probingData;
+	static double clusterUnpaired;
+	static double clusterPaired;
+
+	std::string modifier = getProbing_modifier();
+	int sep = -1;
+	double score;
+
+	callCounter++;
+
+	// incrementally constuct a unique key/hash from the function parameters
+	#ifdef FASTER_getReactivityScore
+	std::size_t key = 0;
+	boost::hash_combine(key, inputSubseq.i); // i and j positions of Subsequence object uniquely identify it
+	boost::hash_combine(key, inputSubseq.j);
+	boost::hash_combine(key, isUnpaired);
+	boost::hash_combine(key, offsetSubseq.i);
+	boost::hash_combine(key, offsetSubseq.j);
+	boost::hash_combine(key, offset);
+
+	if (prevScores.find(key) != prevScores.end()) 
+	{
+		// if the hashkey exists, return the previously calculated result
+		// instead of recalculating it again
+		couldSkipCounter++;
+		return prevScores[key];
+	}
+	#endif
+  
+	if (!isLoaded) {
+		std::string line;
+		std::ifstream infile (getProbing_dataFilename());
+		if (infile.is_open()) 
+		{
+			while (getline (infile,line)) {
+				char *thisLine = strdup(line.c_str());
+				//we expect each line to hold the base position (starting with 1) and the reactivity.
+				if (strcmp(thisLine,"&")==0){
+					sep = probingData.size();
+					continue;
+				}
+				strtok(thisLine, " \t");
+				double reactivity = atof(strtok(NULL, " \t"));	
+				probingData.push_back(reactivity);
+			}
+			infile.close();
+		}
+			
+		// TODO (kmaibach): needs reworking when changing the way the whitespace between two sequences is represented
+		unsigned int inputsLength = 0;
+		std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
+					
+		if (offset) {
+		inputsLength = inputsSequences.at(0).second + inputsSequences.at(1).second;
+		} 
+		else {
+		inputsLength = inputsSequences.at(0).second;
+		}
+		
+		if (probingData.size() < inputsLength) {
+		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' misses " << (inputsLength - probingData.size()) << " data-row(s) " << std::endl << "         compared to the number of nucleotides in your input sequence." << std::endl << "         Missing values will be set to 0.0!" << std::endl;
+		}
+		if (probingData.size() > inputsLength) {
+		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' contains " << (probingData.size()-inputsLength) << " more row(s) " << std::endl << "         than there are nucleotides in your input sequence." << std::endl << "         Exceeding data lines will be ignored!" << std::endl;	
+		}
+			
+		// centroid normalization
+		if (strcmp(getProbing_normalization(), "centroid") == 0) {		
+			int numData = probingData.size();
+			Subsequence base = inputSubseq;
+			double *data = new double[numData];
+			int i = 0;
+			int j = 0;
+			int k;
+			for (i = 0; i < numData; i++) {
+				k = i;
+				if (offset && (i >= (int) inputsSequences.at(0).second || i >= sep))
+				{ 
+					base = offsetSubseq;
+					k = i - sep;
+				
+				}
+				if ((modifier == "DMS") && (base[k] != A_BASE) && (base[k] != C_BASE)) {
+					continue;
+				}
+				if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
+					continue;
+				}
+				if (probingData[i] < 0) {
+					data[j] = 0.0;
+					probingData[i] = 0.0;
+				} 
+				else {
+					data[j] = probingData[i];
+				}
+			j++;
+			}
+
+			double centroids[2];
+			kmeans(2, j, data, centroids);
+			clusterUnpaired = centroids[0];
+			clusterPaired = centroids[1];
+			delete[] data;
+		}
+		
+		if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				*it = CalculatePseudoEnergy(*it,modifier,getProbing_slope(),getProbing_intercept()); //the parameters are: plain reactivity, modifier type, slope, intercept
+			}
+		}
+		if (strcmp(getProbing_normalization(), "logplain") == 0) {
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				if (*it+1.0 < 0.0) {
+					*it = 0.0;
+				} 
+				else {
+					*it = log(*it+1.0);
+				}
+			}
+		}
+		if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
+			double max = 0.0;
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				if (max < *it) max = *it;
+				if (*it < 0.0) *it = 0.0;
+			}
+			if (max > 0.0) {
+				for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+					*it = ((int) ((*it / max) * 10.0)) / 10.0;
+				}
+			}
+		}
+			
+		if (sep > -1)
+		{
+			off_probingData = std::vector<double>(probingData.rbegin(), probingData.rend());
+			probingData.clear();
+		}
+
+		isLoaded = true;
+	}
+	
+	if (offset) {
+		score = calculateScore(offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier) + calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+	}
+	else {
+	score = calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+	}
+
+	#ifdef PRINT_INFO
+	// print a bunch of (debugging) information
+	if (callCounter % 50000 == 0)
+	{
+		std::cout << "Called getReactivityScore " << callCounter << " times. Could return early " << couldSkipCounter << " times." << std::endl;
+
+		printf("Generated hash: %ld, Func Params: Seq1: %d, %d; Seq2: %d, %d, isUnpaired: %d, offset: %d\n", key, inputSubseq.i, inputSubseq.j, offsetSubseq.i, offsetSubseq.j, isUnpaired, offset);
+		printf("Seq1: ");
+		for (int i=inputSubseq.i; i<inputSubseq.j; i++) 
+		{
+			if (inputSubseq[i] == A_BASE) printf("A");
+			else if (inputSubseq[i] == G_BASE) printf("G");
+			else if (inputSubseq[i] == C_BASE) printf("C");
+			else if (inputSubseq[i] == U_BASE) printf("U");
+		}
+
+		printf("\nSeq2: ");
+		for (int i=offsetSubseq.i; i<offsetSubseq.j; i++) 
+		{
+			if (offsetSubseq[i] == A_BASE) printf("A");
+			else if (offsetSubseq[i] == G_BASE) printf("G");
+			else if (offsetSubseq[i] == C_BASE) printf("C");
+			else if (offsetSubseq[i] == U_BASE) printf("U");
+		}
+		printf("\nScore: %f\n\n", score);
+	}
+	#endif 
+
+	#ifdef FASTER_getReactivityScore
+	prevScores[key] = score; // add the score to the map for potential lookups in another function call
+	#endif
+
+	return score;
+}
+#else
 
 inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset) {
   static bool isLoaded = false;
@@ -413,6 +570,7 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 	}
 	return score;
 }
+#endif
 
 // two track
 inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq) {

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -1,14 +1,20 @@
 #ifndef PROBING_HH
 #define PROBING_HH
 
-
-#define FASTER_getReactivityScore // turn on/off to switch between old/new implementation
-//#define PRINT_INFO
-
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <time.h>
+
+#define ARRAYLOOKUP // use array to store calc results
+#ifdef ARRAYLOOKUP
+//#define PRECALC // precalculate everything and store results in array (use in combination w/ ARRAYLOOKUP)
+#endif
+
+//#define HASHLOOKUP // use hashmap to store calc results
+#ifdef HASHLOOKUP
+//#define PRINT_INFO // turn on to print debugging information in hash lookup version
+#endif
 
 /*
   Fynn's improvements/suggestions:
@@ -25,13 +31,20 @@
 	-GetReactivityScore:
 		-pass "probingData" vector (and "modifier" string) to calculateScore by reference (makes code about 0.05x- 0.1x faster)
 		-replace reversing of probingData to off_probingData w/ 
-		vector<double> off_probingData(probingData.rbegin(), probingData.rend()); probingData.clear();
+		 vector<double> off_probingData(probingData.rbegin(), probingData.rend()); probingData.clear();
   
   -major adjustments:
-	-GetReactivityScore:
+	-GetReactivityScore (hash version):
 		-keep track of already calculated scores by hashing the function parameters and
 	  	performing a simple hashmap lookup to see if the function was aleady called once
-	  	w/ the same parameters; if so, simply return the previously calculated result (makes code about 5x faster)
+	  	w/ the same parameters (separately for inputSubseq and offsetSubseq);
+		if so, simply return the previously calculated result 
+		-makes code about about 5-10x faster, speedup seems to grow expontentially w/ input
+
+	-GetReactivityScore (array version):
+		-store previously calculated results in one (single track) or two (two track) matrices
+		-and simply retrieve the previously calculated results if they exist
+		-makes code about 1.5-2x faster the the hash version
 */
 
 //Stefans own 1-dimensional k-means clustering
@@ -244,7 +257,7 @@ inline double calculateScore(const Subsequence &Base, const bool isUnpaired, con
 	return score;
 }
 
-#ifdef FASTER_getReactivityScore
+#ifdef HASHLOOKUP
 
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
@@ -253,7 +266,8 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 {
 	static int callCounter = 0;
 	static int couldSkipCounter = 0;
-	static std::unordered_map<std::size_t, double> prevScores; // store previously calculated scores in here
+	static std::unordered_map<std::size_t, double> iSubseqScores; // store previously calculated scores in here
+	static std::unordered_map<std::size_t, double> oSubseqScores; // store previously calculated scores in here
 
 	static bool isLoaded = false;
   	static std::vector<double> off_probingData;
@@ -268,23 +282,18 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 	callCounter++;
 
 	// incrementally constuct a unique key/hash from the function parameters
-	#ifdef FASTER_getReactivityScore
-	std::size_t key = 0;
-	boost::hash_combine(key, inputSubseq.i); // i and j positions of Subsequence object uniquely identify it
-	boost::hash_combine(key, inputSubseq.j);
-	boost::hash_combine(key, isUnpaired);
-	boost::hash_combine(key, offsetSubseq.i);
-	boost::hash_combine(key, offsetSubseq.j);
-	boost::hash_combine(key, offset);
+	std::size_t iKey = 0;
+	std::size_t oKey = 0;
 
-	if (prevScores.find(key) != prevScores.end()) 
-	{
-		// if the hashkey exists, return the previously calculated result
-		// instead of recalculating it again
-		couldSkipCounter++;
-		return prevScores[key];
-	}
-	#endif
+	// build hash for inputSubSeq scores
+	boost::hash_combine(iKey, inputSubseq.i); // i and j positions of Subsequence object uniquely identify it
+	boost::hash_combine(iKey, inputSubseq.j);
+	boost::hash_combine(iKey, isUnpaired);
+
+	// build hash for offsetSubSeq scores
+	boost::hash_combine(oKey, offsetSubseq.i);
+	boost::hash_combine(oKey, offsetSubseq.j);
+	boost::hash_combine(oKey, isUnpaired);
   
 	if (!isLoaded) {
 		std::string line;
@@ -310,10 +319,10 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 		std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
 					
 		if (offset) {
-		inputsLength = inputsSequences.at(0).second + inputsSequences.at(1).second;
+		inputsLength = inputsSequences[0].second + inputsSequences[1].second;
 		} 
 		else {
-		inputsLength = inputsSequences.at(0).second;
+		inputsLength = inputsSequences[0].second;
 		}
 		
 		if (probingData.size() < inputsLength) {
@@ -333,7 +342,7 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 			int k;
 			for (i = 0; i < numData; i++) {
 				k = i;
-				if (offset && (i >= (int) inputsSequences.at(0).second || i >= sep))
+				if (offset && (i >= (int) inputsSequences[0].second || i >= sep))
 				{ 
 					base = offsetSubseq;
 					k = i - sep;
@@ -399,11 +408,34 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 		isLoaded = true;
 	}
 	
-	if (offset) {
-		score = calculateScore(offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier) + calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+	// check if inputSubseq score was already computed once before
+	if (iSubseqScores.find(iKey) != iSubseqScores.end())
+	{
+		score = iSubseqScores[iKey];
 	}
-	else {
-	score = calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+	else
+	{
+		double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData, 
+		                                     clusterPaired, clusterUnpaired, modifier);
+		score = iSubseqScore;
+		iSubseqScores[iKey] = iSubseqScore;
+
+	}
+	
+	// check if offsetSubseq score was already computed once before
+	if (offset) 
+	{
+		if (oSubseqScores.find(oKey) != oSubseqScores.end())
+		{
+			score += oSubseqScores[oKey];
+		}
+		else
+		{
+			double offsetSubseqScore = calculateScore(offsetSubseq, isUnpaired, off_probingData, 
+			                                          clusterPaired, clusterUnpaired, modifier);
+			score += offsetSubseqScore;
+			oSubseqScores[oKey] = offsetSubseqScore;
+		}
 	}
 
 	#ifdef PRINT_INFO
@@ -432,16 +464,231 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 		}
 		printf("\nScore: %f\n\n", score);
 	}
-	#endif 
-
-	#ifdef FASTER_getReactivityScore
-	prevScores[key] = score; // add the score to the map for potential lookups in another function call
 	#endif
 
 	return score;
 }
-#else
+#elif defined(ARRAYLOOKUP)
 
+#ifdef PRECALC
+inline double calculateScoreAdj(const unsigned int Base_i, const unsigned int Base_j, const Subsequence &Base,
+                                const bool isUnpaired, const std::vector<double>& probingData, const double clusterPaired, 
+								const double clusterUnpaired, const std::string& modifier)
+{
+	double score = 0.0;
+
+  	for (unsigned int i = Base_i; i < Base_j && i < probingData.size(); i++)
+	{
+		if ((modifier == "DMS") && (Base[i] != A_BASE) && (Base[i] != C_BASE)) continue;
+    	if ((modifier == "CMCT") && (Base[i] != U_BASE) && (Base[i] != G_BASE)) continue;
+
+		if (strcmp(getProbing_normalization(), "centroid") == 0)
+		{
+			if (isUnpaired) score += fabs(probingData[i] - clusterUnpaired);
+			else score += fabs(probingData[i] - clusterPaired);
+		} 
+		else
+		{
+			if (isUnpaired) score += probingData[i];
+			else score -= probingData[i];
+		}
+	}
+
+	return score;
+}
+#endif
+
+inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset) {
+	static bool isLoaded = false;
+	static std::vector<double> off_probingData;
+	static std::vector<double> probingData;
+
+	unsigned int iLen = inputSubseq.seq->n;
+	unsigned int oLen = offsetSubseq.seq->n;
+	unsigned long iIndex = (iLen * iLen * isUnpaired) + inputSubseq.i * iLen + inputSubseq.j;
+	unsigned long oIndex = (oLen * oLen * isUnpaired) + offsetSubseq.i * oLen + offsetSubseq.j;
+
+	// allocate n*n matrix as single dimensional array and initialize values to 0
+	static double* iSubseqScores = new double[iLen*iLen*2]();
+	static double* oSubseqScores = new double[oLen*oLen*2]();
+
+	int sep = -1;
+	double score;
+
+	static double clusterUnpaired;
+	static double clusterPaired;
+	std::string modifier = getProbing_modifier();
+	
+	if (!isLoaded) 
+	{
+		std::string line;
+		std::ifstream infile (getProbing_dataFilename());
+		if (infile.is_open()) 
+		{
+			while (getline (infile,line)) {
+				char *thisLine = strdup(line.c_str());
+				//we expect each line to hold the base position (starting with 1) and the reactivity.
+				if (strcmp(thisLine,"&")==0){
+					sep = probingData.size();
+					continue;
+				}
+				strtok(thisLine, " \t");
+				double reactivity = atof(strtok(NULL, " \t"));	
+				probingData.push_back(reactivity);
+			}
+			infile.close();
+		}
+			
+		// TODO (kmaibach): needs reworking when changing the way the whitespace between two sequences is represented
+		unsigned int inputsLength = 0;
+		std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
+					
+		if (offset) {
+		inputsLength = inputsSequences[0].second + inputsSequences[1].second;
+		} 
+		else {
+		inputsLength = inputsSequences[0].second;
+		}
+		
+		if (probingData.size() < inputsLength) {
+		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' misses " << (inputsLength - probingData.size()) << " data-row(s) " << std::endl << "         compared to the number of nucleotides in your input sequence." << std::endl << "         Missing values will be set to 0.0!" << std::endl;
+		}
+		if (probingData.size() > inputsLength) {
+		std::cerr << "Warning: chemical probing data file '" << getProbing_dataFilename() << "' contains " << (probingData.size()-inputsLength) << " more row(s) " << std::endl << "         than there are nucleotides in your input sequence." << std::endl << "         Exceeding data lines will be ignored!" << std::endl;	
+		}
+			
+		// centroid normalization
+		if (strcmp(getProbing_normalization(), "centroid") == 0) 
+		{		
+			int numData = probingData.size();
+			Subsequence base = inputSubseq;
+			double *data = new double[numData];
+			int i = 0;
+			int j = 0;
+			int k;
+			for (i = 0; i < numData; i++)
+			{
+				k = i;
+				if (offset && (i >= (int) inputsSequences[0].second || i >= sep))
+				{ 
+					base = offsetSubseq;
+					k = i - sep;
+				
+				}
+				if ((modifier == "DMS") && (base[k] != A_BASE) && (base[k] != C_BASE)) {
+					continue;
+				}
+				if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
+					continue;
+				}
+				if (probingData[i] < 0) {
+					data[j] = 0.0;
+					probingData[i] = 0.0;
+				} 
+				else {
+					data[j] = probingData[i];
+				}
+				j++;
+			}
+
+			double centroids[2];
+			kmeans(2, j, data, centroids);
+			clusterUnpaired = centroids[0];
+			clusterPaired = centroids[1];
+			delete[] data;
+		}
+	
+		if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				*it = CalculatePseudoEnergy(*it,modifier,getProbing_slope(),getProbing_intercept()); //the parameters are: plain reactivity, modifier type, slope, intercept
+			}
+		}
+		if (strcmp(getProbing_normalization(), "logplain") == 0) {
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				if (*it+1.0 < 0.0) {
+					*it = 0.0;
+				} 
+				else {
+					*it = log(*it+1.0);
+				}
+			}
+		}
+		if ((strcmp(getProbing_normalization(), "asProbabilities") == 0)) {
+			double max = 0.0;
+			for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+				if (max < *it) max = *it;
+				if (*it < 0.0) *it = 0.0;
+			}
+			if (max > 0.0) {
+				for(std::vector<double>::iterator it = probingData.begin(); it != probingData.end(); it++) {
+					*it = ((int) ((*it / max) * 10.0)) / 10.0;
+				}
+			}
+		}
+		
+		if (sep > -1)
+		{
+			off_probingData = std::vector<double>(probingData.rbegin(), probingData.rend());
+			probingData.clear();
+		}
+
+		isLoaded = true;
+
+		#ifdef PRECALC
+		for (unsigned int i=0; i<iLen-1; i++)
+		{
+			for (unsigned int j=i+1; j<iLen; j++) 
+			{
+				unsigned long iIndex = (iLen * iLen * isUnpaired) + i * iLen + j;
+				iSubseqScores[iIndex] = calculateScoreAdj(i, j, inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+			}
+		}
+		for (unsigned int i=0; i<oLen-1; i++)
+		{
+			for (unsigned int j=i+1; j<oLen; j++)
+			{
+				unsigned long oIndex = (oLen * oLen * isUnpaired) + i * oLen + j;
+				oSubseqScores[oIndex] = calculateScoreAdj(i, j, offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier);
+			}
+		}
+		#endif
+	}
+	
+	#ifdef PRECALC
+	score = iSubseqScores[iIndex];
+	if (offset) score += oSubseqScores[oIndex];
+	
+	#else
+	if (iSubseqScores[iIndex]) // check if score was already calculated once (meaning if value at index isn't 0 anymore)
+	{
+		score = iSubseqScores[iIndex];
+	}
+	else
+	{
+		double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData, clusterPaired, clusterUnpaired, modifier);
+		score = iSubseqScore;
+		iSubseqScores[iIndex] = iSubseqScore;
+	}
+
+	if (offset)
+	{
+		if (oSubseqScores[oIndex])
+		{
+			score += oSubseqScores[oIndex];
+		}
+		else
+		{
+			double oSubseqScore = calculateScore(offsetSubseq, isUnpaired, off_probingData, clusterPaired, clusterUnpaired, modifier);
+			score += oSubseqScore;
+			oSubseqScores[oIndex] = oSubseqScore;
+		}
+	}
+	#endif
+
+	return score;
+}
+
+#else
 inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUnpaired, const Subsequence &offsetSubseq, const bool offset) {
   static bool isLoaded = false;
   static std::vector<double> off_probingData;
@@ -477,9 +724,9 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
     std::vector<std::pair<const char*, unsigned> > inputsSequences = getInputs();
                 
     if (offset) {
-      inputsLength = inputsSequences.at(0).second + inputsSequences.at(1).second;
+      inputsLength = inputsSequences[0].second + inputsSequences[1].second;
     } else {
-      inputsLength = inputsSequences.at(0).second;
+      inputsLength = inputsSequences[0].second;
     }
        
     if (probingData.size() < inputsLength) {
@@ -500,7 +747,7 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 	    for (i = 0; i < numData; i++) {
 		    k = i;
 		    if (offset) {
-		      if(i >= (int) inputsSequences.at(0).second || i >= sep) {
+		      if(i >= (int) inputsSequences[0].second || i >= sep) {
 				    base = offsetSubseq;
 					  k = i - sep;
 			    }
@@ -511,11 +758,11 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 			  if ((modifier == "CMCT") && (base[k] != U_BASE) && (base[k] != G_BASE)) {
 			    continue;
 			  }
-			  if (probingData.at(i) < 0) {
+			  if (probingData[i] < 0) {
 			    data[j] = 0.0;
-				  probingData.at(i) = 0.0;
+				  probingData[i] = 0.0;
 			  } else {
-				  data[j] = probingData.at(i);
+				  data[j] = probingData[i];
 			  }
         j++;
       }
@@ -556,7 +803,7 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
         
 	  if (sep > -1){
 		  for (int i=probingData.size()-1; i>=sep; i--){
-			  off_probingData.insert(off_probingData.begin(), probingData.at(i));
+			  off_probingData.insert(off_probingData.begin(), probingData[i]);
 			  probingData.erase(probingData.begin() + i);
 		  }
 	  }
@@ -583,3 +830,5 @@ inline double getReactivityScore(const Subsequence &inputSubseq, const bool isUn
 }
 
 #endif
+
+


### PR DESCRIPTION
In the GAP-C compilations that require it, the getReactivityScore function is often (re)called with identical function parameters multiple times. Currently it is recalculating the same score with every such function call. So instead of recalculating a score that has already been calculated multiple times, we can significantly speed up the runtimes of the GAP-C compilations by appropriately storing the calculated scores and by performing a lookup at the beginning of every function call to check if a score from an earlier function call with identical parameters already exists. If so, we can directly return this score without having to recalculate it over and over again. This reduces the runtimes of the GAP-C compilations I tested (rnahybrid.gap and nodangle.gap) by a lot (see benchmark plots).
![rnahybrid_mem](https://user-images.githubusercontent.com/87138636/196682153-e7aea5f3-bd5a-49bb-a6e7-de8f9adda315.png)
![rnahybrid_time](https://user-images.githubusercontent.com/87138636/196682161-9fa7464a-2d23-4d3b-bf80-6b8fe760908c.png)
![gen_rnahybrid_mem](https://user-images.githubusercontent.com/87138636/196682194-7ccbcda5-dd97-449f-8163-b90a1831c56d.png)
![gen_rnahybrid_time](https://user-images.githubusercontent.com/87138636/196682196-58f51bef-386a-47d6-a6f9-5ba26a33a89d.png)
![nodangle_mem](https://user-images.githubusercontent.com/87138636/196682197-1fa1880e-4a90-4d7f-a511-aead53f11205.png)
![nodangle_time](https://user-images.githubusercontent.com/87138636/196682199-b6886828-529c-4bf6-93ba-0a67de1ac443.png)
