### PR TITLE
Change probing function declarations to static

### DIFF
--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -448,10 +448,10 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
 
 
     if (sep > -1) {
-      for (int i=probingData.size()-1; i >= sep; i--) {
-        off_probingData.insert(off_probingData.begin(), probingData.at(i));
-        probingData.erase(probingData.begin() + i);
-      }
+      /* add the content of probingData to off_probingData
+         in reverse oder and remove the values from probingData */
+      off_probingData = std::vector(probingData.rbegin(), probingData.rend());
+      probingData.clear();
     }
 
     isLoaded = true;

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -136,12 +136,12 @@ inline void kmeans(int numCluster, int numData, double *input,
 }
 
 // START: STOLEN FROM RNASTRUCTURE
-inline double Gammadist(double data, double shape, double loc, double scale) {
+static double Gammadist(double data, double shape, double loc, double scale) {
   return (1 / scale) * pow((data - loc) * (1 / scale), (shape - 1)) * \
          exp(-(1 / scale) * (data - loc)) / tgamma(shape);
 }
 
-inline double Potential(double data, const double (*params)[8],
+static double Potential(double data, const double (*params)[8],
                         double kT) {
   /* params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for
      shape, loc scale of component 1
@@ -164,7 +164,7 @@ inline double Potential(double data, const double (*params)[8],
    reactivity distribution per modifier, or the "classic" Deigan et al. bonus
    term when no modifier or an unrecognized modifier is provided. */
 
-inline double CalculatePseudoEnergy(double data, const std::string &modifier,
+static double CalculatePseudoEnergy(double data, const std::string &modifier,
                                     double slope, double intercept) {
   static const double (*params)[8];
   static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
@@ -233,7 +233,7 @@ inline double CalculatePseudoEnergy(double data, const std::string &modifier,
 }
 
 // END STOLEN FROM RNASTRUCTURE
-inline double calculateScore(const Subsequence &Base, const bool isUnpaired,
+static double calculateScore(const Subsequence &Base, const bool isUnpaired,
                              const std::vector<double> &probingData,
                              const double clusterPaired,
                              const double clusterUnpaired,
@@ -264,7 +264,7 @@ inline double calculateScore(const Subsequence &Base, const bool isUnpaired,
   return score;
 }
 
-inline double getReactivityScore(const Subsequence &inputSubseq,
+static double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq,
                                  const bool offset) {
@@ -309,13 +309,10 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
       containing all previously calculated scores */
 
   unsigned int ciTrilSum = (inputSubseq.i * (inputSubseq.i + 1)) / 2;
-  unsigned int coTrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
 
   // calculate the correct indices for the score lookup/storing
   unsigned int iIndex = (iTriuSum * isUnpaired) + inputSubseq.i * iLen +
                         inputSubseq.j - ciTrilSum;
-  unsigned int oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen +
-                        offsetSubseq.j - coTrilSum;
 
   /* -allocate a static vector/1d-array (size of upper triangular matrix only)
       to store/look up the scores
@@ -480,6 +477,9 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
        (in the GAPC compilations that call this function, offset is either
        always true or always false) */
     static std::vector<double> oSubseqScores(oTriuSum * 2);
+    unsigned int coTrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
+    unsigned int oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen +
+                           offsetSubseq.j - coTrilSum;
 
     if (oSubseqScores[oIndex]) {
       score += oSubseqScores[oIndex];

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -448,10 +448,10 @@ inline double getReactivityScore(const Subsequence &inputSubseq,
 
 
     if (sep > -1) {
-      /* add the content of probingData to off_probingData
-         in reverse oder and remove the values from probingData */
-      off_probingData = std::vector(probingData.rbegin(), probingData.rend());
-      probingData.clear();
+      for (int i=probingData.size()-1; i >= sep; i--) {
+        off_probingData.insert(off_probingData.begin(), probingData.at(i));
+        probingData.erase(probingData.begin() + i);
+      }
     }
 
     isLoaded = true;


### PR DESCRIPTION
In the [probing.h](https://github.com/jlab/fold-grammars/blob/master/Extensions/probing.hh)-file, all functions (including helper functions) are declared as `inline` functions. This means that these functions get "inlined" whenever they are called, which essentially means that instead of invoking a regular function call, the code these functions contain gets "copied" to wherever the respective `inline` function was called and is then executed "inline". This can significantly speed up your code if the `inline` function is short (about 1-2 lines at most) and is called a lot during runtime, because in such a case the overhead of a function call might take longer than inlining it and executing just the body of the function. Inlining longer functions is most likely going to slow down your code though, because in this case inlining consumes more time than the overhead of a regular function call. 

While the overloaded `getReactivityScore` needs to be delared as `inline` for the linking to work properly, the remaining helper functions don't need to be declared as `inline`, since they don't need to be visible outside of the [probing.h](https://github.com/jlab/fold-grammars/blob/master/Extensions/probing.hh)-file. And since most of the helper functions are quite long, I figured it would probably speed up the probing if we don't declare them as `inline`, which the following benchmark confirms:

![nodangle_probing_static_bm](https://user-images.githubusercontent.com/87138636/205627017-0e2167b5-7e36-4f1a-a57e-0b3bfbf380f9.png)

As you can see, the execution time for this compilation (`gapc -p alg_probing nodangle.gap`) when declaring the helper functions as `static`, which restricts their visibility to only this translation unit (aka this source file) and obviously doesn't inline them, is noticeably shorter than the execution time of this compilation with `inline` function declarations. The memory usage is unchanged. The speedup isn't that huge, but still quite significant for this small of an adjustment.

(Side note: I also moved the lookup index calculation for the `offsetSubseq` to only be done when `offset == true` (i.e. calling the program in two-track mode). Before this adjustment the lookup index calculation was also done in single-track mode, which didn't affect the execution time  much but is still unnecessary).