### PR TITLE
Precalculate scores for all possible subsequences in getReactivityScore

### DIFF
--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -1,6 +1,8 @@
 #ifndef PROBING_HH
 #define PROBING_HH
 
+#define NEW
+
 #include <time.h>
 #include <utility>
 #include <vector>
@@ -9,33 +11,33 @@
 #include <string>
 
 // Stefans own 1-dimensional k-means clustering
-static void kmeans(int numCluster, int numData, double *input,
-                   double centroids[]) {
+static void kmeans(int numCluster, int numData, long double *input,
+                   long double centroids[]) {
   const int MAXRUNS = 1000;
   const int MAXITERATIONS = 100;
-  const double CONVERGENCE = 0.01;
+  const long double CONVERGENCE = 0.01;
 
   int i, j, k, r = 0;
   srand(time(NULL));
 
   int sumRunIterations = 0;
   if (numData >= numCluster) {
-    double *clusterSumDistances = static_cast<double *>(malloc(
-      sizeof(double) * numCluster));
-    double *bestCentroids = static_cast<double *>(
-      malloc(sizeof(double) * numCluster));
-    double bestVariance = static_cast<double>(HUGE_VAL);
+    long double *clusterSumDistances = static_cast<long double *>(malloc(
+      sizeof(long double) * numCluster));
+    long double *bestCentroids = static_cast<long double *>(
+      malloc(sizeof(long double) * numCluster));
+    long double bestVariance = static_cast<long double>(HUGE_VAL);
     int *assignments = static_cast<int *>(malloc(sizeof(int) * numData));
     int *numClusterMembers = static_cast<int *>(
       malloc(sizeof(int) * numCluster));
-    double minDist_point2cluster = static_cast<double>(HUGE_VAL);
+    long double minDist_point2cluster = static_cast<long double>(HUGE_VAL);
     int minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
-    double dist_point2cluster = static_cast<double>(HUGE_VAL);
-    double variance = static_cast<double>(HUGE_VAL);
-    double newVariance = static_cast<double>(HUGE_VAL);
+    long double dist_point2cluster = static_cast<long double>(HUGE_VAL);
+    long double variance = static_cast<long double>(HUGE_VAL);
+    long double newVariance = static_cast<long double>(HUGE_VAL);
     int randomIndex = 0;
     int iteration = 1;
-    double varianceChange = static_cast<double>(HUGE_VAL);
+    long double varianceChange = static_cast<long double>(HUGE_VAL);
 
     for (r = 0; r < MAXRUNS; r++) {
       // select random data points as initial centroids
@@ -121,7 +123,7 @@ static void kmeans(int numCluster, int numData, double *input,
   /* for return: the cluster for the unpaired probing values always comes first,
      i.e. 0 = unpaired = higher value; 1 = paired = lower value */
   if (centroids[0] < centroids[1]) {
-    double help = centroids[0];
+    long double help = centroids[0];
     centroids[0] = centroids[1];
     centroids[1] = help;
   }
@@ -129,29 +131,29 @@ static void kmeans(int numCluster, int numData, double *input,
   // centroids[0] = 2.1133;
   // centroids[1] = 0.116405;
   std::cout << "Cluster info ("
-            << (sumRunIterations/static_cast<double>(MAXRUNS))
+            << (sumRunIterations/static_cast<long double>(MAXRUNS))
             << " avg. iterations for "<< MAXRUNS
             << " alternative start points): unpaired = " << centroids[0]
             << ", paired = " << centroids[1] << "\n";
 }
 
 // START: STOLEN FROM RNASTRUCTURE
-static double Gammadist(double data, double shape, double loc, double scale) {
+static long double Gammadist(long double data, long double shape, long double loc, long double scale) {
   return (1 / scale) * pow((data - loc) * (1 / scale), (shape - 1)) * \
          exp(-(1 / scale) * (data - loc)) / tgamma(shape);
 }
 
-static double Potential(double data, const double (*params)[8],
-                        double kT) {
+static long double Potential(long double data, const long double (*params)[8],
+                        long double kT) {
   /* params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for
      shape, loc scale of component 1
      j=3,4,5 for shape, loc, scale of component 2 and j=6,7 for weights of
      components 1 and 2 respectively. */
-  double pairedprob = params[0][6]*Gammadist(data, params[0][0], params[0][1],
+  long double pairedprob = params[0][6]*Gammadist(data, params[0][0], params[0][1],
                                              params[0][2]) +
                       params[0][7]*Gammadist(data, params[0][3], params[0][4],
                                              params[0][5]);
-  double unpairedprob = params[1][6]*Gammadist(data, params[1][0], params[1][1],
+  long double unpairedprob = params[1][6]*Gammadist(data, params[1][0], params[1][1],
                                                params[1][2]) +
                         params[1][7]*Gammadist(data, params[1][3], params[1][4],
                                                params[1][5]);
@@ -164,10 +166,10 @@ static double Potential(double data, const double (*params)[8],
    reactivity distribution per modifier, or the "classic" Deigan et al. bonus
    term when no modifier or an unrecognized modifier is provided. */
 
-static double CalculatePseudoEnergy(double data, const std::string &modifier,
-                                    double slope, double intercept) {
-  static const double (*params)[8];
-  static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
+static long double CalculatePseudoEnergy(long double data, const std::string &modifier,
+                                    long double slope, long double intercept) {
+  static const long double (*params)[8];
+  static constexpr long double SHAPE_params[2][8] = {{1.82374892807, 0.0,
                                                  0.0830320205572,
                                                  1.82374892807, 0.0,
                                                  0.0830320205572,
@@ -177,7 +179,7 @@ static double CalculatePseudoEnergy(double data, const std::string &modifier,
                                                  0.0, 0.374470347084,
                                                  1.27932240423, 0.0}};
 
-  static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0,
+  static constexpr long double DMS_params[2][8] = {{1.36184674022, 0.0,
                                                0.0876565404957, 1.36184674022,
                                                0.0, 0.0876565404957,
                                                1.36184674022, 0.0},
@@ -186,7 +188,7 @@ static double CalculatePseudoEnergy(double data, const std::string &modifier,
                                                0.0, 0.37015874678,
                                                1.33486621438, 0.0}};
 
-  static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0,
+  static constexpr long double CMCT_params[2][8] = {{0.668918986169, 0.0,
                                                 0.268161495459, 0.668918986169,
                                                 0.0, 0.268161495459,
                                                 0.668918986169, 0.0},
@@ -225,18 +227,52 @@ static double CalculatePseudoEnergy(double data, const std::string &modifier,
   if (data < 0 || (slope == 0 && intercept == 0)) {
     return 0;
   }
-  // double val2 = log(data+1.0)*slope+intercept;
-  double kT = 5.904976983149999;
-  double val = Potential(data, params, kT);
+  // long double val2 = log(data+1.0)*slope+intercept;
+  long double kT = 5.904976983149999;
+  long double val = Potential(data, params, kT);
 
   return val;
 }
 
-static void calcBaseScores(double **baseScores,
+#include <limits>
+static long double calculateScore(const Subsequence &Base, const bool isUnpaired,
+                             const std::vector<long double> &probingData,
+                             const long double clusterPaired,
+                             const long double clusterUnpaired,
+                             const bool hasDMSModifier,
+                             const bool hasCMCTModifier,
+                             const bool isCentroidProbNorm) {
+  long double score = 0.0;
+  for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++) {
+    if (hasDMSModifier && (Base[i] != A_BASE) && (Base[i] != C_BASE)) {
+      continue;
+    } else if (hasCMCTModifier && (Base[i] != U_BASE) && (Base[i] != G_BASE)) {
+      continue;
+    }
+    if (isCentroidProbNorm) {
+      if (isUnpaired) {
+        score += fabs(probingData.at(i) - clusterUnpaired);
+      } else {
+        score += fabs(probingData.at(i) - clusterPaired);
+      }
+    } else {
+      if (isUnpaired) {
+        score += probingData.at(i);
+      } else {
+        score -= probingData.at(i);
+      }
+    }
+  }
+  return score;
+}
+
+#ifdef NEW
+
+static void calcBaseScores(long double **baseScores,
                            const Subsequence &Base,
-                           const std::vector<double> &probingData,
-                           const double clusterPaired,
-                           const double clusterUnpaired,
+                           const std::vector<long double> &probingData,
+                           const long double clusterPaired,
+                           const long double clusterUnpaired,
                            const bool hasDMSModifier,
                            const bool hasCMCTModifier,
                            const bool isCentroidProbNorm) {
@@ -248,12 +284,12 @@ static void calcBaseScores(double **baseScores,
   const unsigned int lookupSize = Base.seq->n + 1;
 
   // allocate space and store pointers in baseScores
-  baseScores[0] = new double[lookupSize];  // paired base scores
-  baseScores[1] = new double[lookupSize];  // unpaired base scores
+  baseScores[0] = new long double[lookupSize];  // paired base scores
+  baseScores[1] = new long double[lookupSize];  // unpaired base scores
   baseScores[0][0] = 0.0;
   baseScores[1][0] = 0.0;
 
-  double pairedScore = 0.0, unpairedScore = 0.0;
+  long double pairedScore = 0.0, unpairedScore = 0.0;
 
 
   for (unsigned int i = 0; i < probingData.size(); i++) {
@@ -283,16 +319,16 @@ static void calcBaseScores(double **baseScores,
   }
 }
 
-static double getReactivityScore(const Subsequence &inputSubseq,
+static long double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq,
                                  const bool offset) {
   static bool isLoaded = false;
-  static std::vector<double> off_probingData;
-  static std::vector<double> probingData;
+  static std::vector<long double> off_probingData;
+  static std::vector<long double> probingData;
 
-  static double clusterUnpaired;
-  static double clusterPaired;
+  static long double clusterUnpaired;
+  static long double clusterPaired;
 
   // get the probing modifier and check its value
   static const std::string modifier = getProbing_modifier();
@@ -306,7 +342,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
   /* store pointers to the pairedBaseScores and unpairedBaseScores
      arrays for both inputSubseq and offsetSubseq
   */
-  static double *inputSubseqBaseScores[2], *offsetSubseqBaseScores[2];
+  static long double *inputSubseqBaseScores[2], *offsetSubseqBaseScores[2];
 
   if (!isLoaded) {
     int sep = -1;
@@ -322,7 +358,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
           continue;
         }
         strtok(thisLine, " \t");
-        double reactivity = atof(strtok(NULL, " \t"));
+        long double reactivity = atof(strtok(NULL, " \t"));
         probingData.push_back(reactivity);
       }
       infile.close();
@@ -363,8 +399,8 @@ static double getReactivityScore(const Subsequence &inputSubseq,
     if (isCentroidProbNorm) {
       int numData = probingData.size();
       Subsequence base = inputSubseq;
-      double *data = static_cast<double *>(
-        malloc(sizeof(double) * numData));
+      long double *data = static_cast<long double *>(
+        malloc(sizeof(long double) * numData));
       int i = 0;
       int j = 0;
       int k;
@@ -392,8 +428,8 @@ static double getReactivityScore(const Subsequence &inputSubseq,
         }
         j++;
       }
-      double *centroids = static_cast<double *>(
-        malloc(sizeof(double) * 2));
+      long double *centroids = static_cast<long double *>(
+        malloc(sizeof(long double) * 2));
       kmeans(2, j, data, centroids);
       clusterUnpaired = centroids[0];
       clusterPaired = centroids[1];
@@ -401,7 +437,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
       free(centroids);
 
     } else if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-      for (std::vector<double>::iterator it = probingData.begin();
+      for (std::vector<long double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         // the parameters are: plain reactivity, modifier type, slope, intercept
         *it = CalculatePseudoEnergy(*it, modifier, getProbing_slope(),
@@ -409,7 +445,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
       }
 
     } else if (strcmp(getProbing_normalization(), "logplain") == 0) {
-      for (std::vector<double>::iterator it = probingData.begin();
+      for (std::vector<long double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         if (*it+1.0 < 0.0) {
           *it = 0.0;
@@ -418,14 +454,14 @@ static double getReactivityScore(const Subsequence &inputSubseq,
         }
       }
     } else if (strcmp(getProbing_normalization(), "asProbabilities") == 0) {
-      double max = 0.0;
-      for (std::vector<double>::iterator it = probingData.begin();
+      long double max = 0.0;
+      for (std::vector<long double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         if (max < *it) max = *it;
         if (*it < 0.0) *it = 0.0;
       }
       if (max > 0.0) {
-        for (std::vector<double>::iterator it = probingData.begin();
+        for (std::vector<long double>::iterator it = probingData.begin();
             it != probingData.end(); it++) {
           *it = static_cast<int>(((*it / max) * 10.0)) / 10.0;
         }
@@ -460,11 +496,30 @@ static double getReactivityScore(const Subsequence &inputSubseq,
      to position i from the score sum up to position j
      (for inputSubseq and offsetSubseq respectively)
   */
-  double iSubseqScore = inputSubseqBaseScores[isUnpaired][inputSubseq.j] -
+  long double iSubseqScore = inputSubseqBaseScores[isUnpaired][inputSubseq.j] -
                         inputSubseqBaseScores[isUnpaired][inputSubseq.i];
-  double oSubseqScore = offsetSubseqBaseScores[isUnpaired][offsetSubseq.j] -
+  long double oSubseqScore = offsetSubseqBaseScores[isUnpaired][offsetSubseq.j] -
                         offsetSubseqBaseScores[isUnpaired][offsetSubseq.i];
 
+  // long double score = iSubseqScore + oSubseqScore * offset;
+  // long double old_score = calculateScore(inputSubseq, isUnpaired, probingData,
+  //                                   clusterPaired, clusterUnpaired, hasDMSModifier,
+  //                                   hasCMCTModifier, isCentroidProbNorm);
+  
+  // long double currdiff = fabs(old_score - score);
+  // if (currdiff < 0.0) currdiff *= -1;
+  // bool same = currdiff < std::numeric_limits<long double>::epsilon();
+  // static int samec = 0, diffc = 0;
+  // static long double mxdiff = 0.0;
+  // mxdiff = max(mxdiff, currdiff);
+  // if (!same) {
+  //   diffc++;
+  //   if (diffc % 10000000 == 0) {
+  //     printf("Same count: %d, Diff count: %d, Difference: %.30Lf, Max diff so far: %.30Lf\n", samec, diffc, old_score - score, mxdiff);
+  //   }
+  // } else samec++;
+
+  // return score;
 
   /* multiply oSubseqScore with offset so it will only be
      added to the score if offset is true, i.e. in two-track mode
@@ -473,15 +528,269 @@ static double getReactivityScore(const Subsequence &inputSubseq,
   return iSubseqScore + oSubseqScore * offset;
 }
 
+#else
+
+static long double getReactivityScore(const Subsequence &inputSubseq,
+                                 const bool isUnpaired,
+                                 const Subsequence &offsetSubseq,
+                                 const bool offset) {
+  static bool isLoaded = false;
+  static std::vector<long double> off_probingData;
+  static std::vector<long double> probingData;
+
+  long double score;
+
+  static long double clusterUnpaired;
+  static long double clusterPaired;
+
+  // get the probing modifier and check its value
+  static const std::string modifier = getProbing_modifier();
+  static const bool hasDMSModifier = modifier == "DMS";
+  static const bool hasCMCTModifier = modifier == "CMCT";
+
+  // check if the probing normalization method is "centroid"
+  static const bool isCentroidProbNorm = strcmp(getProbing_normalization(),
+                                                "centroid") == 0;
+
+  /* -store scores in a lookup matrix to avoid recalculations
+     -store only the upper triangular matrix (as a 1d-array)
+     ->makes figuring out the correct indices a bit more
+       complicated and adds slightly more compute compared
+       to using a NxN array, but roughly cuts the required memory in half
+      -the offset parameter is only true in two-track mode (see overloads
+       below), so the creation of a second array for offset score
+       lookups is only done if the offset parameter is true */
+
+  static unsigned int iLen = inputSubseq.seq->n + 1;
+  static unsigned int oLen = offsetSubseq.seq->n + 1;
+
+  static unsigned int iTriuSum = (iLen * (iLen + 1)) / 2;
+  static unsigned int oTriuSum = (oLen * (oLen + 1)) / 2;
+
+  /* -calculate sums of the size/number of cells in the lower triangular
+      matrix up to row inputSubseq.i/offsetSubseq.i based on the
+      current inputSubseq/offsetSubseq input parameters
+     -these are needed to calculate the correct index in the
+      1d array representing the upper triangular matrix
+      containing all previously calculated scores */
+
+  unsigned int ciTrilSum = (inputSubseq.i * (inputSubseq.i + 1)) / 2;
+
+  // calculate the correct indices for the score lookup/storing
+  unsigned int iIndex = (iTriuSum * isUnpaired) + inputSubseq.i * iLen +
+                        inputSubseq.j - ciTrilSum;
+
+  /* -allocate a static vector/1d-array (size of upper triangular matrix only)
+      to store/look up the scores
+     -requires additional dimension to store both paired and unpaired scores */
+  static std::vector<long double> iSubseqScores(iTriuSum * 2);
+
+  if (!isLoaded) {
+    int sep = -1;
+    std::string line;
+    std::ifstream infile(getProbing_dataFilename());
+    if (infile.is_open()) {
+      while (getline(infile, line)) {
+        char *thisLine = strdup(line.c_str());
+        /* we expect each line to hold the base position (starting with 1) and
+           the reactivity. */
+        if (strcmp(thisLine, "&") == 0) {
+          sep = probingData.size();
+          continue;
+        }
+        strtok(thisLine, " \t");
+        long double reactivity = atof(strtok(NULL, " \t"));
+        probingData.push_back(reactivity);
+      }
+      infile.close();
+    }
+
+    /* TODO (kmaibach): needs reworking when changing the way the whitespace
+       between two sequences is represented */
+    unsigned int inputsLength = 0;
+    std::vector<std::pair<const char*, unsigned> > inputsSequences = \
+      getInputs();
+
+    if (offset) {
+      inputsLength = inputsSequences.at(0).second + \
+                     inputsSequences.at(1).second;
+    } else {
+      inputsLength = inputsSequences.at(0).second;
+    }
+
+    if (probingData.size() < inputsLength) {
+      std::cerr << "Warning: chemical probing data file '"
+                << getProbing_dataFilename() << "' misses "
+                << (inputsLength - probingData.size()) << " data-row(s) "
+                << std::endl << "         compared to the number of nucleotides"
+                << " in your input sequence." << std::endl
+                << "         Missing values will be set to 0.0!" << std::endl;
+    }
+    if (probingData.size() > inputsLength) {
+      std::cerr << "Warning: chemical probing data file '"
+                << getProbing_dataFilename() << "' contains "
+                << (probingData.size()-inputsLength) << " more row(s) "
+                << std::endl << "         than there are nucleotides in your "
+                << "input sequence." << std::endl
+                << "         Exceeding data lines will be ignored!"
+                << std::endl;
+    }
+
+    // centroid normalization
+    if (isCentroidProbNorm) {
+      int numData = probingData.size();
+      Subsequence base = inputSubseq;
+      long double *data = static_cast<long double *>(
+        malloc(sizeof(long double) * numData));
+      int i = 0;
+      int j = 0;
+      int k;
+      for (i = 0; i < numData; i++) {
+        k = i;
+        if (offset) {
+          if (i >= static_cast<int>(inputsSequences.at(0).second)
+              || i >= sep) {
+            base = offsetSubseq;
+            k = i - sep;
+          }
+        }
+        if (hasDMSModifier && (base[k] != A_BASE) &&
+            (base[k] != C_BASE)) {
+          continue;
+        } else if (hasCMCTModifier && (base[k] != U_BASE) &&
+            (base[k] != G_BASE)) {
+          continue;
+        }
+        if (probingData.at(i) < 0) {
+          data[j] = 0.0;
+          probingData.at(i) = 0.0;
+        } else {
+          data[j] = probingData.at(i);
+        }
+        j++;
+      }
+      long double *centroids = static_cast<long double *>(
+        malloc(sizeof(long double) * 2));
+      kmeans(2, j, data, centroids);
+      clusterUnpaired = centroids[0];
+      clusterPaired = centroids[1];
+      free(data);
+      free(centroids);
+
+    } else if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
+      for (std::vector<long double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        // the parameters are: plain reactivity, modifier type, slope, intercept
+        *it = CalculatePseudoEnergy(*it, modifier, getProbing_slope(),
+                                    getProbing_intercept());
+      }
+
+    } else if (strcmp(getProbing_normalization(), "logplain") == 0) {
+      for (std::vector<long double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        if (*it+1.0 < 0.0) {
+          *it = 0.0;
+        } else {
+          *it = log(*it+1.0);
+        }
+      }
+    } else if (strcmp(getProbing_normalization(), "asProbabilities") == 0) {
+      long double max = 0.0;
+      for (std::vector<long double>::iterator it = probingData.begin();
+          it != probingData.end(); it++) {
+        if (max < *it) max = *it;
+        if (*it < 0.0) *it = 0.0;
+      }
+      if (max > 0.0) {
+        for (std::vector<long double>::iterator it = probingData.begin();
+            it != probingData.end(); it++) {
+          *it = static_cast<int>(((*it / max) * 10.0)) / 10.0;
+        }
+      }
+    }
+
+
+    if (sep > -1) {
+      for (int i=probingData.size()-1; i >= sep; i--) {
+        off_probingData.insert(off_probingData.begin(), probingData.at(i));
+        probingData.erase(probingData.begin() + i);
+      }
+    }
+
+    isLoaded = true;
+  }
+
+  /* -check if score was already calculated once
+     (meaning if value at index isn't 0 anymore)
+    -if so, simply use that score instead of recalculating
+    -if it doesn't exist yet, calculate it and store it in
+     the lookup array */
+
+  if (iSubseqScores[iIndex]) {
+    score = iSubseqScores[iIndex];
+  } else {
+    long double iSubseqScore = calculateScore(inputSubseq, isUnpaired, probingData,
+                                         clusterPaired, clusterUnpaired,
+                                         hasDMSModifier, hasCMCTModifier,
+                                         isCentroidProbNorm);
+    score = iSubseqScore;
+    iSubseqScores[iIndex] = iSubseqScore;
+  }
+
+  // if offset is true, do the same thing
+  if (offset) {
+    /* only allocate array for offset Subseq scores if offset is true
+       (in the GAPC compilations that call this function, offset is either
+       always true or always false) */
+    static std::vector<long double> oSubseqScores(oTriuSum * 2);
+    unsigned int coTrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
+    unsigned int oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen +
+                           offsetSubseq.j - coTrilSum;
+
+    if (oSubseqScores[oIndex]) {
+      score += oSubseqScores[oIndex];
+    } else {
+      long double oSubseqScore = calculateScore(offsetSubseq, isUnpaired,
+                                           off_probingData, clusterPaired,
+                                           clusterUnpaired,
+                                           hasDMSModifier, hasCMCTModifier,
+                                           isCentroidProbNorm);
+      score += oSubseqScore;
+      oSubseqScores[oIndex] = oSubseqScore;
+    }
+  }
+  
+  long double old_score = calculateScore(inputSubseq, isUnpaired, probingData,
+                                         clusterPaired, clusterUnpaired,
+                                         hasDMSModifier, hasCMCTModifier,
+                                         isCentroidProbNorm);
+  long double currdiff = fabs(old_score - score);
+  bool same = currdiff < std::numeric_limits<long double>::epsilon();
+  static int samec = 0, diffc = 0;
+  static long double mxdiff = 0.0;
+  mxdiff = max(mxdiff, currdiff);
+  if (!same) {
+    diffc++;
+  } else samec++;
+
+  if (samec % 100000 == 0) {
+      printf("Same count: %d, Diff count: %d, Difference: %.30f, Max diff so far: %.30f\n", samec, diffc, old_score - score, mxdiff);
+    }
+
+  return score;
+}
+
+#endif
+
 // two track
-inline double getReactivityScore(const Subsequence &inputSubseq,
+inline long double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq) {
   return getReactivityScore(inputSubseq, isUnpaired, offsetSubseq, true);
 }
 
 // single track
-inline double getReactivityScore(const Subsequence &inputSubseq,
+inline long double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired) {
   return getReactivityScore(inputSubseq, isUnpaired, inputSubseq, false);
 }

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -253,6 +253,7 @@ static void precalculateScores(score_matrix *baseScores,
   */
 
   const unsigned int lookupSize = Base.seq->n + 1;
+  const unsigned int seqLen = Base.seq->n;
 
   // rows for paired and unpaired score matrices
   (*baseScores)[0] = std::vector<std::vector<double>>(lookupSize);
@@ -269,7 +270,7 @@ static void precalculateScores(score_matrix *baseScores,
     pairedScore = 0.0;
     unpairedScore = 0.0;
 
-    for (unsigned int j = i; j < probingData.size(); j++) {
+    for (unsigned int j = i; j < probingData.size() && j < seqLen; j++) {
       // continuously sum up the paired and unpaired score for every base
       if (!(hasDMSModifier && Base[j] != A_BASE && Base[j] != C_BASE) &&
           !(hasCMCTModifier && Base[j] != U_BASE && Base[j] != G_BASE)) {

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -452,7 +452,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
                    inputSubseq, probingData, clusterPaired,
                    clusterUnpaired, hasDMSModifier,
                    hasCMCTModifier, isCentroidProbNorm);
-    
+
     if (offset) {
       calcBaseScores(offsetSubseqBaseScores,
                      offsetSubseq, off_probingData, clusterPaired,

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -1,8 +1,6 @@
 #ifndef PROBING_HH
 #define PROBING_HH
 
-#define NEW
-
 #include <time.h>
 #include <utility>
 #include <vector>
@@ -11,33 +9,33 @@
 #include <string>
 
 // Stefans own 1-dimensional k-means clustering
-static void kmeans(int numCluster, int numData, long double *input,
-                   long double centroids[]) {
+static void kmeans(int numCluster, int numData, double *input,
+                   double centroids[]) {
   const int MAXRUNS = 1000;
   const int MAXITERATIONS = 100;
-  const long double CONVERGENCE = 0.01;
+  const double CONVERGENCE = 0.01;
 
   int i, j, k, r = 0;
   srand(time(NULL));
 
   int sumRunIterations = 0;
   if (numData >= numCluster) {
-    long double *clusterSumDistances = static_cast<long double *>(malloc(
-      sizeof(long double) * numCluster));
-    long double *bestCentroids = static_cast<long double *>(
-      malloc(sizeof(long double) * numCluster));
-    long double bestVariance = static_cast<long double>(HUGE_VAL);
+    double *clusterSumDistances = static_cast<double *>(malloc(
+      sizeof(double) * numCluster));
+    double *bestCentroids = static_cast<double *>(
+      malloc(sizeof(double) * numCluster));
+    double bestVariance = static_cast<double>(HUGE_VAL);
     int *assignments = static_cast<int *>(malloc(sizeof(int) * numData));
     int *numClusterMembers = static_cast<int *>(
       malloc(sizeof(int) * numCluster));
-    long double minDist_point2cluster = static_cast<long double>(HUGE_VAL);
+    double minDist_point2cluster = static_cast<double>(HUGE_VAL);
     int minDistIndex_point2cluster = static_cast<int>(HUGE_VAL);
-    long double dist_point2cluster = static_cast<long double>(HUGE_VAL);
-    long double variance = static_cast<long double>(HUGE_VAL);
-    long double newVariance = static_cast<long double>(HUGE_VAL);
+    double dist_point2cluster = static_cast<double>(HUGE_VAL);
+    double variance = static_cast<double>(HUGE_VAL);
+    double newVariance = static_cast<double>(HUGE_VAL);
     int randomIndex = 0;
     int iteration = 1;
-    long double varianceChange = static_cast<long double>(HUGE_VAL);
+    double varianceChange = static_cast<double>(HUGE_VAL);
 
     for (r = 0; r < MAXRUNS; r++) {
       // select random data points as initial centroids
@@ -123,7 +121,7 @@ static void kmeans(int numCluster, int numData, long double *input,
   /* for return: the cluster for the unpaired probing values always comes first,
      i.e. 0 = unpaired = higher value; 1 = paired = lower value */
   if (centroids[0] < centroids[1]) {
-    long double help = centroids[0];
+    double help = centroids[0];
     centroids[0] = centroids[1];
     centroids[1] = help;
   }
@@ -131,32 +129,32 @@ static void kmeans(int numCluster, int numData, long double *input,
   // centroids[0] = 2.1133;
   // centroids[1] = 0.116405;
   std::cout << "Cluster info ("
-            << (sumRunIterations/static_cast<long double>(MAXRUNS))
+            << (sumRunIterations/static_cast<double>(MAXRUNS))
             << " avg. iterations for "<< MAXRUNS
             << " alternative start points): unpaired = " << centroids[0]
             << ", paired = " << centroids[1] << "\n";
 }
 
 // START: STOLEN FROM RNASTRUCTURE
-static long double Gammadist(long double data, long double shape,
-                             long double loc, long double scale) {
+static double Gammadist(double data, double shape,
+                             double loc, double scale) {
   return (1 / scale) * pow((data - loc) * (1 / scale), (shape - 1)) * \
          exp(-(1 / scale) * (data - loc)) / tgamma(shape);
 }
 
-static long double Potential(long double data, const long double (*params)[8],
-                        long double kT) {
+static double Potential(double data, const double (*params)[8],
+                        double kT) {
   /* params[0] is for paired, params[0] for unpaired...params[][j], j=0,1,2 for
      shape, loc scale of component 1
      j=3,4,5 for shape, loc, scale of component 2 and j=6,7 for weights of
      components 1 and 2 respectively. */
-  long double pairedprob = params[0][6]*Gammadist(data, params[0][0],
+  double pairedprob = params[0][6]*Gammadist(data, params[0][0],
                                                   params[0][1],
                                                   params[0][2]) +
                            params[0][7]*Gammadist(data, params[0][3],
                                                   params[0][4],
                                                   params[0][5]);
-  long double unpairedprob = params[1][6]*Gammadist(data, params[1][0],
+  double unpairedprob = params[1][6]*Gammadist(data, params[1][0],
                                                     params[1][1],
                                                     params[1][2]) +
                              params[1][7]*Gammadist(data, params[1][3],
@@ -171,12 +169,12 @@ static long double Potential(long double data, const long double (*params)[8],
    reactivity distribution per modifier, or the "classic" Deigan et al. bonus
    term when no modifier or an unrecognized modifier is provided. */
 
-static long double CalculatePseudoEnergy(long double data,
+static double CalculatePseudoEnergy(double data,
                                          const std::string &modifier,
-                                         long double slope,
-                                         long double intercept) {
-  static const long double (*params)[8];
-  static constexpr long double SHAPE_params[2][8] = {{1.82374892807, 0.0,
+                                         double slope,
+                                         double intercept) {
+  static const double (*params)[8];
+  static constexpr double SHAPE_params[2][8] = {{1.82374892807, 0.0,
                                                  0.0830320205572,
                                                  1.82374892807, 0.0,
                                                  0.0830320205572,
@@ -186,7 +184,7 @@ static long double CalculatePseudoEnergy(long double data,
                                                  0.0, 0.374470347084,
                                                  1.27932240423, 0.0}};
 
-  static constexpr long double DMS_params[2][8] = {{1.36184674022, 0.0,
+  static constexpr double DMS_params[2][8] = {{1.36184674022, 0.0,
                                                0.0876565404957, 1.36184674022,
                                                0.0, 0.0876565404957,
                                                1.36184674022, 0.0},
@@ -195,7 +193,7 @@ static long double CalculatePseudoEnergy(long double data,
                                                0.0, 0.37015874678,
                                                1.33486621438, 0.0}};
 
-  static constexpr long double CMCT_params[2][8] = {{0.668918986169, 0.0,
+  static constexpr double CMCT_params[2][8] = {{0.668918986169, 0.0,
                                                 0.268161495459, 0.668918986169,
                                                 0.0, 0.268161495459,
                                                 0.668918986169, 0.0},
@@ -234,111 +232,88 @@ static long double CalculatePseudoEnergy(long double data,
   if (data < 0 || (slope == 0 && intercept == 0)) {
     return 0;
   }
-  // long double val2 = log(data+1.0)*slope+intercept;
-  long double kT = 5.904976983149999;
-  long double val = Potential(data, params, kT);
+  // double val2 = log(data+1.0)*slope+intercept;
+  double kT = 5.904976983149999;
+  double val = Potential(data, params, kT);
 
   return val;
 }
 
-#include <limits>
-#include <algorithm>
+typedef std::vector<std::vector<std::vector<double>>> score_matrix;
 
-static long double calculateScore(const Subsequence &Base,
-                             const bool isUnpaired,
-                             const std::vector<long double> &probingData,
-                             const long double clusterPaired,
-                             const long double clusterUnpaired,
-                             const bool hasDMSModifier,
-                             const bool hasCMCTModifier,
-                             const bool isCentroidProbNorm) {
-  long double score = 0.0;
-  for (unsigned int i = Base.i; i < Base.j && i < probingData.size(); i++) {
-    if (hasDMSModifier && (Base[i] != A_BASE) && (Base[i] != C_BASE)) {
-      continue;
-    } else if (hasCMCTModifier && (Base[i] != U_BASE) && (Base[i] != G_BASE)) {
-      continue;
-    }
-    if (isCentroidProbNorm) {
-      if (isUnpaired) {
-        score += fabs(probingData.at(i) - clusterUnpaired);
-      } else {
-        score += fabs(probingData.at(i) - clusterPaired);
-      }
-    } else {
-      if (isUnpaired) {
-        score += probingData.at(i);
-      } else {
-        score -= probingData.at(i);
-      }
-    }
-  }
-  return score;
-}
-
-#ifdef NEW
-
-static void calcBaseScores(long double **baseScores,
-                           const Subsequence &Base,
-                           const std::vector<long double> &probingData,
-                           const long double clusterPaired,
-                           const long double clusterUnpaired,
-                           const bool hasDMSModifier,
-                           const bool hasCMCTModifier,
-                           const bool isCentroidProbNorm) {
-  /* precalculate the score from the first base 
-     up to every base position for cheap and fast
-     score calculation in getReactivityScore
+static void precalculateScores(score_matrix &baseScores,
+                               const Subsequence &Base,
+                               const std::vector<double> &probingData,
+                               const double clusterPaired,
+                               const double clusterUnpaired,
+                               const bool hasDMSModifier,
+                               const bool hasCMCTModifier,
+                               const bool isCentroidProbNorm) {
+  /* precalculate the scores for all possible subsequences
   */
 
   const unsigned int lookupSize = Base.seq->n + 1;
 
-  // allocate space and store pointers in baseScores
-  baseScores[0] = new long double[lookupSize];  // paired base scores
-  baseScores[1] = new long double[lookupSize];  // unpaired base scores
-  baseScores[0][0] = 0.0;
-  baseScores[1][0] = 0.0;
+  // rows for paired and unpaired score matrices
+  baseScores[0] = std::vector<std::vector<double>>(lookupSize);
+  baseScores[1] = std::vector<std::vector<double>>(lookupSize);
 
-  long double pairedScore = 0.0, unpairedScore = 0.0;
+  double pairedScore, unpairedScore;
+  int offset_j;
 
+  for (unsigned int i = 0; i < lookupSize - 1; i++) {
+    // columns for paired and unpaired scores matrices
+    baseScores[0][i] = std::vector<double>(lookupSize - i);
+    baseScores[1][i] = std::vector<double>(lookupSize - i);
 
-  for (unsigned int i = 0; i < probingData.size(); i++) {
-    // continuously sum up the paired and unpaired score for every base
-    if (!(hasDMSModifier && Base[i] != A_BASE && Base[i] != C_BASE) &&
-        !(hasCMCTModifier && Base[i] != U_BASE && Base[i] != G_BASE)) {
-      if (isCentroidProbNorm) {
-        unpairedScore += fabs(probingData[i] - clusterUnpaired);
-        pairedScore += fabs(probingData[i] - clusterPaired);
-      } else {
-        unpairedScore += probingData[i];
-        pairedScore -= probingData[i];
+    pairedScore = 0.0;
+    unpairedScore = 0.0;
+
+    for (unsigned int j = i; j < probingData.size(); j++) {
+      // continuously sum up the paired and unpaired score for every base
+      if (!(hasDMSModifier && Base[j] != A_BASE && Base[j] != C_BASE) &&
+          !(hasCMCTModifier && Base[j] != U_BASE && Base[j] != G_BASE)) {
+        if (isCentroidProbNorm) {
+          unpairedScore += fabs(probingData[j] - clusterUnpaired);
+          pairedScore += fabs(probingData[j] - clusterPaired);
+        } else {
+          unpairedScore += probingData[j];
+          pairedScore -= probingData[j];
+        }
       }
+
+      // need to offset j since only upper triangular matrix is stored
+      offset_j = j - i + 1;
+
+      baseScores[0][i][offset_j] = pairedScore;
+      baseScores[1][i][offset_j] = unpairedScore;
     }
 
-    baseScores[0][i + 1] = pairedScore;
-    baseScores[1][i + 1] = unpairedScore;
-  }
+    baseScores[0][lookupSize - 1] = std::vector<double>(1, 0.0);
+    baseScores[1][lookupSize - 1] = std::vector<double>(1, 0.0);
 
-  /* assign the final score to all bases which don't have their
-     own probingData entry so the calculation in getReactivityScore
-     also works for these bases
-  */
-  for (unsigned int i = probingData.size() + 1; i < lookupSize; i++) {
-    baseScores[0][i] = pairedScore;
-    baseScores[1][i] = unpairedScore;
+    /* assign the final score to all bases which don't have their
+       own probingData entry so the calculation in getReactivityScore
+       also works for these bases
+    */
+    for (unsigned int j = probingData.size() + 1; j < lookupSize; j++) {
+      offset_j = j - i + 1;
+      baseScores[0][i][offset_j] = pairedScore;
+      baseScores[1][i][offset_j] = unpairedScore;
+    }
   }
 }
 
-static long double getReactivityScore(const Subsequence &inputSubseq,
+static double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq,
                                  const bool offset) {
   static bool isLoaded = false;
-  static std::vector<long double> off_probingData;
-  static std::vector<long double> probingData;
+  static std::vector<double> off_probingData;
+  static std::vector<double> probingData;
 
-  static long double clusterUnpaired;
-  static long double clusterPaired;
+  static double clusterUnpaired;
+  static double clusterPaired;
 
   // get the probing modifier and check its value
   static const std::string modifier = getProbing_modifier();
@@ -349,10 +324,10 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
   static const bool isCentroidProbNorm = strcmp(getProbing_normalization(),
                                                 "centroid") == 0;
 
-  /* store pointers to the pairedBaseScores and unpairedBaseScores
-     arrays for both inputSubseq and offsetSubseq
-  */
-  static long double *inputSubseqBaseScores[2], *offsetSubseqBaseScores[2];
+  static score_matrix inputSubseqBaseScores(2), _offsetSubseqBaseScores(2);
+  static score_matrix &offsetSubseqBaseScores = offset ?
+                                                _offsetSubseqBaseScores :
+                                                inputSubseqBaseScores;
 
   if (!isLoaded) {
     int sep = -1;
@@ -368,7 +343,7 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
           continue;
         }
         strtok(thisLine, " \t");
-        long double reactivity = atof(strtok(NULL, " \t"));
+        double reactivity = atof(strtok(NULL, " \t"));
         probingData.push_back(reactivity);
       }
       infile.close();
@@ -409,8 +384,8 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
     if (isCentroidProbNorm) {
       int numData = probingData.size();
       Subsequence base = inputSubseq;
-      long double *data = static_cast<long double *>(
-        malloc(sizeof(long double) * numData));
+      double *data = static_cast<double *>(
+        malloc(sizeof(double) * numData));
       int i = 0;
       int j = 0;
       int k;
@@ -438,8 +413,8 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
         }
         j++;
       }
-      long double *centroids = static_cast<long double *>(
-        malloc(sizeof(long double) * 2));
+      double *centroids = static_cast<double *>(
+        malloc(sizeof(double) * 2));
       kmeans(2, j, data, centroids);
       clusterUnpaired = centroids[0];
       clusterPaired = centroids[1];
@@ -447,7 +422,7 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
       free(centroids);
 
     } else if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-      for (std::vector<long double>::iterator it = probingData.begin();
+      for (std::vector<double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         // the parameters are: plain reactivity, modifier type, slope, intercept
         *it = CalculatePseudoEnergy(*it, modifier, getProbing_slope(),
@@ -455,7 +430,7 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
       }
 
     } else if (strcmp(getProbing_normalization(), "logplain") == 0) {
-      for (std::vector<long double>::iterator it = probingData.begin();
+      for (std::vector<double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         if (*it+1.0 < 0.0) {
           *it = 0.0;
@@ -464,14 +439,14 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
         }
       }
     } else if (strcmp(getProbing_normalization(), "asProbabilities") == 0) {
-      long double max = 0.0;
-      for (std::vector<long double>::iterator it = probingData.begin();
+      double max = 0.0;
+      for (std::vector<double>::iterator it = probingData.begin();
           it != probingData.end(); it++) {
         if (max < *it) max = *it;
         if (*it < 0.0) *it = 0.0;
       }
       if (max > 0.0) {
-        for (std::vector<long double>::iterator it = probingData.begin();
+        for (std::vector<double>::iterator it = probingData.begin();
             it != probingData.end(); it++) {
           *it = static_cast<int>(((*it / max) * 10.0)) / 10.0;
         }
@@ -484,53 +459,38 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
         probingData.erase(probingData.begin() + i);
       }
     }
-
-    /* calculate the score sum for all bases
-       (for inputSubseq and offsetSubseq respectively)
-       and store the pointers to the arrays with those
-       scores in inputSubseqBaseScores and offsetSubseqBaseScores
+    /* precalculate the scores sum for all possible
+       subsequences (for inputSubseq and offsetSubseq respectively)
+       and store the scores in inputSubseqBaseScores
+       and offsetSubseqBaseScores
     */
-    calcBaseScores(inputSubseqBaseScores,
-                   inputSubseq, probingData, clusterPaired,
-                   clusterUnpaired, hasDMSModifier,
-                   hasCMCTModifier, isCentroidProbNorm);
-    calcBaseScores(offsetSubseqBaseScores,
-                   offsetSubseq, off_probingData, clusterPaired,
-                   clusterUnpaired, hasDMSModifier,
-                   hasCMCTModifier, isCentroidProbNorm);
+    precalculateScores(inputSubseqBaseScores,
+                       inputSubseq, probingData, clusterPaired,
+                       clusterUnpaired, hasDMSModifier,
+                       hasCMCTModifier, isCentroidProbNorm);
+
+    if (offset) {
+      /* only precalculate offset scores if offset == true
+         (calculating them if offset == false causes an error)
+      */
+      precalculateScores(offsetSubseqBaseScores,
+                         offsetSubseq, off_probingData, clusterPaired,
+                         clusterUnpaired, hasDMSModifier,
+                         hasCMCTModifier, isCentroidProbNorm);
+    }
 
     isLoaded = true;
   }
 
-  /* calculate the score by subtracting the score sum up 
-     to position i from the score sum up to position j
-     (for inputSubseq and offsetSubseq respectively)
-  */
-  long double iSubseqScore = inputSubseqBaseScores[isUnpaired][inputSubseq.j] -
-                        inputSubseqBaseScores[isUnpaired][inputSubseq.i];
-  long double oSubseqScore =
-  offsetSubseqBaseScores[isUnpaired][offsetSubseq.j] -
-                        offsetSubseqBaseScores[isUnpaired][offsetSubseq.i];
+  double iSubseqScore = inputSubseqBaseScores[isUnpaired]
+                                             [inputSubseq.i]
+                                             [inputSubseq.j -
+                                              inputSubseq.i];
 
-  // long double score = iSubseqScore + oSubseqScore * offset;
-  // long double old_score = calculateScore(inputSubseq,
-  //                                   isUnpaired, probingData,
-  //                                   clusterPaired, clusterUnpaired,
-  //                                   hasDMSModifier,
-  //                                   hasCMCTModifier, isCentroidProbNorm);
-
-  // long double currdiff = fabs(old_score - score);
-  // if (currdiff < 0.0) currdiff *= -1;
-  // bool same = currdiff < std::numeric_limits<long double>::epsilon();
-  // static int samec = 0, diffc = 0;
-  // static long double mxdiff = 0.0;
-  // mxdiff = max(mxdiff, currdiff);
-  // if (!same) {
-  //   diffc++;
-  //   }
-  // } else samec++;
-
-  // return score;
+  double oSubseqScore = offsetSubseqBaseScores[isUnpaired]
+                                              [offsetSubseq.i]
+                                              [offsetSubseq.j -
+                                               offsetSubseq.i];
 
   /* multiply oSubseqScore with offset so it will only be
      added to the score if offset is true, i.e. in two-track mode
@@ -539,268 +499,15 @@ static long double getReactivityScore(const Subsequence &inputSubseq,
   return iSubseqScore + oSubseqScore * offset;
 }
 
-#else
-
-static long double getReactivityScore(const Subsequence &inputSubseq,
-                                 const bool isUnpaired,
-                                 const Subsequence &offsetSubseq,
-                                 const bool offset) {
-  static bool isLoaded = false;
-  static std::vector<long double> off_probingData;
-  static std::vector<long double> probingData;
-
-  long double score;
-
-  static long double clusterUnpaired;
-  static long double clusterPaired;
-
-  // get the probing modifier and check its value
-  static const std::string modifier = getProbing_modifier();
-  static const bool hasDMSModifier = modifier == "DMS";
-  static const bool hasCMCTModifier = modifier == "CMCT";
-
-  // check if the probing normalization method is "centroid"
-  static const bool isCentroidProbNorm = strcmp(getProbing_normalization(),
-                                                "centroid") == 0;
-
-  /* -store scores in a lookup matrix to avoid recalculations
-     -store only the upper triangular matrix (as a 1d-array)
-     ->makes figuring out the correct indices a bit more
-       complicated and adds slightly more compute compared
-       to using a NxN array, but roughly cuts the required memory in half
-      -the offset parameter is only true in two-track mode (see overloads
-       below), so the creation of a second array for offset score
-       lookups is only done if the offset parameter is true */
-
-  static unsigned int iLen = inputSubseq.seq->n + 1;
-  static unsigned int oLen = offsetSubseq.seq->n + 1;
-
-  static unsigned int iTriuSum = (iLen * (iLen + 1)) / 2;
-  static unsigned int oTriuSum = (oLen * (oLen + 1)) / 2;
-
-  /* -calculate sums of the size/number of cells in the lower triangular
-      matrix up to row inputSubseq.i/offsetSubseq.i based on the
-      current inputSubseq/offsetSubseq input parameters
-     -these are needed to calculate the correct index in the
-      1d array representing the upper triangular matrix
-      containing all previously calculated scores */
-
-  unsigned int ciTrilSum = (inputSubseq.i * (inputSubseq.i + 1)) / 2;
-
-  // calculate the correct indices for the score lookup/storing
-  unsigned int iIndex = (iTriuSum * isUnpaired) + inputSubseq.i * iLen +
-                        inputSubseq.j - ciTrilSum;
-
-  /* -allocate a static vector/1d-array (size of upper triangular matrix only)
-      to store/look up the scores
-     -requires additional dimension to store both paired and unpaired scores */
-  static std::vector<long double> iSubseqScores(iTriuSum * 2);
-
-  if (!isLoaded) {
-    int sep = -1;
-    std::string line;
-    std::ifstream infile(getProbing_dataFilename());
-    if (infile.is_open()) {
-      while (getline(infile, line)) {
-        char *thisLine = strdup(line.c_str());
-        /* we expect each line to hold the base position (starting with 1) and
-           the reactivity. */
-        if (strcmp(thisLine, "&") == 0) {
-          sep = probingData.size();
-          continue;
-        }
-        strtok(thisLine, " \t");
-        long double reactivity = atof(strtok(NULL, " \t"));
-        probingData.push_back(reactivity);
-      }
-      infile.close();
-    }
-
-    /* TODO (kmaibach): needs reworking when changing the way the whitespace
-       between two sequences is represented */
-    unsigned int inputsLength = 0;
-    std::vector<std::pair<const char*, unsigned> > inputsSequences = \
-      getInputs();
-
-    if (offset) {
-      inputsLength = inputsSequences.at(0).second + \
-                     inputsSequences.at(1).second;
-    } else {
-      inputsLength = inputsSequences.at(0).second;
-    }
-
-    if (probingData.size() < inputsLength) {
-      std::cerr << "Warning: chemical probing data file '"
-                << getProbing_dataFilename() << "' misses "
-                << (inputsLength - probingData.size()) << " data-row(s) "
-                << std::endl << "         compared to the number of nucleotides"
-                << " in your input sequence." << std::endl
-                << "         Missing values will be set to 0.0!" << std::endl;
-    }
-    if (probingData.size() > inputsLength) {
-      std::cerr << "Warning: chemical probing data file '"
-                << getProbing_dataFilename() << "' contains "
-                << (probingData.size()-inputsLength) << " more row(s) "
-                << std::endl << "         than there are nucleotides in your "
-                << "input sequence." << std::endl
-                << "         Exceeding data lines will be ignored!"
-                << std::endl;
-    }
-
-    // centroid normalization
-    if (isCentroidProbNorm) {
-      int numData = probingData.size();
-      Subsequence base = inputSubseq;
-      long double *data = static_cast<long double *>(
-        malloc(sizeof(long double) * numData));
-      int i = 0;
-      int j = 0;
-      int k;
-      for (i = 0; i < numData; i++) {
-        k = i;
-        if (offset) {
-          if (i >= static_cast<int>(inputsSequences.at(0).second)
-              || i >= sep) {
-            base = offsetSubseq;
-            k = i - sep;
-          }
-        }
-        if (hasDMSModifier && (base[k] != A_BASE) &&
-            (base[k] != C_BASE)) {
-          continue;
-        } else if (hasCMCTModifier && (base[k] != U_BASE) &&
-            (base[k] != G_BASE)) {
-          continue;
-        }
-        if (probingData.at(i) < 0) {
-          data[j] = 0.0;
-          probingData.at(i) = 0.0;
-        } else {
-          data[j] = probingData.at(i);
-        }
-        j++;
-      }
-      long double *centroids = static_cast<long double *>(
-        malloc(sizeof(long double) * 2));
-      kmeans(2, j, data, centroids);
-      clusterUnpaired = centroids[0];
-      clusterPaired = centroids[1];
-      free(data);
-      free(centroids);
-
-    } else if (strcmp(getProbing_normalization(), "RNAstructure") == 0) {
-      for (std::vector<long double>::iterator it = probingData.begin();
-          it != probingData.end(); it++) {
-        // the parameters are: plain reactivity, modifier type, slope, intercept
-        *it = CalculatePseudoEnergy(*it, modifier, getProbing_slope(),
-                                    getProbing_intercept());
-      }
-
-    } else if (strcmp(getProbing_normalization(), "logplain") == 0) {
-      for (std::vector<long double>::iterator it = probingData.begin();
-          it != probingData.end(); it++) {
-        if (*it+1.0 < 0.0) {
-          *it = 0.0;
-        } else {
-          *it = log(*it+1.0);
-        }
-      }
-    } else if (strcmp(getProbing_normalization(), "asProbabilities") == 0) {
-      long double max = 0.0;
-      for (std::vector<long double>::iterator it = probingData.begin();
-          it != probingData.end(); it++) {
-        if (max < *it) max = *it;
-        if (*it < 0.0) *it = 0.0;
-      }
-      if (max > 0.0) {
-        for (std::vector<long double>::iterator it = probingData.begin();
-            it != probingData.end(); it++) {
-          *it = static_cast<int>(((*it / max) * 10.0)) / 10.0;
-        }
-      }
-    }
-
-
-    if (sep > -1) {
-      for (int i=probingData.size()-1; i >= sep; i--) {
-        off_probingData.insert(off_probingData.begin(), probingData.at(i));
-        probingData.erase(probingData.begin() + i);
-      }
-    }
-
-    isLoaded = true;
-  }
-
-  /* -check if score was already calculated once
-     (meaning if value at index isn't 0 anymore)
-    -if so, simply use that score instead of recalculating
-    -if it doesn't exist yet, calculate it and store it in
-     the lookup array */
-
-  if (iSubseqScores[iIndex]) {
-    score = iSubseqScores[iIndex];
-  } else {
-    long double iSubseqScore = calculateScore(inputSubseq, isUnpaired,
-                                         probingData,
-                                         clusterPaired, clusterUnpaired,
-                                         hasDMSModifier, hasCMCTModifier,
-                                         isCentroidProbNorm);
-    score = iSubseqScore;
-    iSubseqScores[iIndex] = iSubseqScore;
-  }
-
-  // if offset is true, do the same thing
-  if (offset) {
-    /* only allocate array for offset Subseq scores if offset is true
-       (in the GAPC compilations that call this function, offset is either
-       always true or always false) */
-    static std::vector<long double> oSubseqScores(oTriuSum * 2);
-    unsigned int coTrilSum = (offsetSubseq.i * (offsetSubseq.i + 1)) / 2;
-    unsigned int oIndex = (oTriuSum * isUnpaired) + offsetSubseq.i * oLen +
-                           offsetSubseq.j - coTrilSum;
-
-    if (oSubseqScores[oIndex]) {
-      score += oSubseqScores[oIndex];
-    } else {
-      long double oSubseqScore = calculateScore(offsetSubseq, isUnpaired,
-                                           off_probingData, clusterPaired,
-                                           clusterUnpaired,
-                                           hasDMSModifier, hasCMCTModifier,
-                                           isCentroidProbNorm);
-      score += oSubseqScore;
-      oSubseqScores[oIndex] = oSubseqScore;
-    }
-  }
-
-  long double old_score = calculateScore(inputSubseq, isUnpaired, probingData,
-                                         clusterPaired, clusterUnpaired,
-                                         hasDMSModifier, hasCMCTModifier,
-                                         isCentroidProbNorm);
-  long double currdiff = fabs(old_score - score);
-  bool same = currdiff < std::numeric_limits<long double>::epsilon();
-  static int samec = 0, diffc = 0;
-  static long double mxdiff = 0.0;
-  mxdiff = max(mxdiff, currdiff);
-  if (!same) {
-    diffc++;
-  } else {
-    samec++;
-  }
-
-  return score;
-}
-
-#endif
-
 // two track
-inline long double getReactivityScore(const Subsequence &inputSubseq,
+inline double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired,
                                  const Subsequence &offsetSubseq) {
   return getReactivityScore(inputSubseq, isUnpaired, offsetSubseq, true);
 }
 
 // single track
-inline long double getReactivityScore(const Subsequence &inputSubseq,
+inline double getReactivityScore(const Subsequence &inputSubseq,
                                  const bool isUnpaired) {
   return getReactivityScore(inputSubseq, isUnpaired, inputSubseq, false);
 }

--- a/Extensions/probing.hh
+++ b/Extensions/probing.hh
@@ -289,20 +289,6 @@ static double getReactivityScore(const Subsequence &inputSubseq,
                                  const Subsequence &offsetSubseq,
                                  const bool offset) {
   static bool isLoaded = false;
-  static std::vector<double> off_probingData;
-  static std::vector<double> probingData;
-
-  static double clusterUnpaired;
-  static double clusterPaired;
-
-  // get the probing modifier and check its value
-  static const std::string modifier = getProbing_modifier();
-  static const bool hasDMSModifier = modifier == "DMS";
-  static const bool hasCMCTModifier = modifier == "CMCT";
-
-  // check if the probing normalization method is "centroid"
-  static const bool isCentroidProbNorm = strcmp(getProbing_normalization(),
-                                                "centroid") == 0;
 
   /* store pointers to the pairedBaseScores and unpairedBaseScores
      arrays for both inputSubseq and offsetSubseq
@@ -313,6 +299,20 @@ static double getReactivityScore(const Subsequence &inputSubseq,
                                            inputSubseqBaseScores;
 
   if (!isLoaded) {
+    std::vector<double> off_probingData;
+    std::vector<double> probingData;
+
+    double clusterUnpaired = 0.0;
+    double clusterPaired = 0.0;
+
+    // get the probing modifier and check its value
+    const std::string modifier = getProbing_modifier();
+    const bool hasDMSModifier = modifier == "DMS";
+    const bool hasCMCTModifier = modifier == "CMCT";
+
+    // check if the probing normalization method is "centroid"
+    const bool isCentroidProbNorm = strcmp(getProbing_normalization(),
+                                           "centroid") == 0;
     int sep = -1;
     std::string line;
     std::ifstream infile(getProbing_dataFilename());
@@ -352,8 +352,7 @@ static double getReactivityScore(const Subsequence &inputSubseq,
                 << std::endl << "         compared to the number of nucleotides"
                 << " in your input sequence." << std::endl
                 << "         Missing values will be set to 0.0!" << std::endl;
-    }
-    if (probingData.size() > inputsLength) {
+    } else if (probingData.size() > inputsLength) {
       std::cerr << "Warning: chemical probing data file '"
                 << getProbing_dataFilename() << "' contains "
                 << (probingData.size()-inputsLength) << " more row(s) "


### PR DESCRIPTION
<details open>
<summary>Description of initial idea

</summary>

While thinking about how the reactivity score is actually being calculated in the `calculateScore` function, I found another way to calculate the score that is even quicker than the combination of the caching/lookups from PR #53 and the avoidance of unnecessary string comparisons from PR #54. I realized that `calculateScore` essentially just iteratively sums up the `probingData` values from the `.shape`-files (let's call them "basescores") for the bases of the current `Subsequence`. This sum can also be calculated by subtracting the sum of the basescores from the beginning of the sequence to the base at position `i` of the current `Subsequence` from the sum of the basescores from the beginning of the sequence to the base at position `j` of the current `Subsequence`:

```
# "Sequence" stands for the entire input sequence
score(Subsequence(i, j)) = basescore_sum(Sequence(0, j)) - basescore_sum(Sequence(0, i))
```

 This means that instead of calculating the score for a `Subsequence` iteratively in O(n) time, we can also calculate the same score in O(1) if we precalculate the sums of the basescores up to every base of the input sequence, which can be done in O(n). For clarification consider the following example:

 ```
 # for simplicity, let's ignore the complete calculateScore implementation
 # and assume it just sums up the values
 # (the algorithm still works the same with the real calculateScore implementation)

 Sequence = "AUGCUG"
 #               A    U     G     C    U    G
 probingData = [0.4, 0.6, -0.5, -0.1, 0.8, 0.7]

 subseq_1 = Sequence[1:5]  #  UGCU
 subseq_2 = Sequence[0:3]  #  AUG
 subseq_3 = Sequence[3:6]  #  CUG

 def calculateScore(i, j):
    # i and j are the start and end bases/positions
    # of the Subsequence (j is not inclusive)
     sum = 0
     for x in range(i, j):
         sum += probingData[x]
     return sum

 score_1 = calculateScore(1, 5)  # 0.6 - 0.5 - 0.1 + 0.8 = 0.8
 score_2 = calculateScore(0, 3)  # 0.4 + 0.6 - 0.5 = 0.5
 score_3 = calculateScore(3, 6)  # -0.1 + 0.8 + 0.7 = 1.4

# generating baseScoreSums in O(n)
 sum = 0
 baseScoreSums = [0]
 for value in probingData:
     sum += value
     baseScoreSums.append(sum)

# baseScoreSums = [0, 0.4, 1, 0.5, 0.4, 1.2, 1.9]

def fast_score(i, j):
    # i and j are the start and end bases/positions
    # of the Subsequence (j is not inclusive)
    return baseScoreSums[j] - baseScoreSums[i]

fast_score_1 = fast_score(1, 5) = 0.8  #  1.2 - 0.4 = 0.8
fast_score_2 = fast_score(0, 3) = 0.5  #  0.5 - 0 = 0.5
fast_score_3 = fast_score(3, 6) = 1.4 #  1.9 - 0.5 = 1.4

# fast_score and calculateScore return the same scores
# while fast_score can calculate them in O(1) instead of O(n)
```

I implemented this new approach to calculate the reactivity scores during the probing, compared it to all the major probing speedups from the previous PRs (#53, #54) and got the following results:

![nodangle_probing_final](https://user-images.githubusercontent.com/87138636/205981137-400499b1-8017-4b9d-9f47-b527fec90448.png)

As you can see, this implementation is noticeably faster than the last major improvement (avoid unnecessary string comparions, #54, blue line) and about twice as fast as the first improvement (lookups/caching of previously calculated scores, #53, red line). And since we now only need to calculate and store the basescore basescore sums for every base of the input sequence (O(n)), the program also requires way less memory than the other improvements (which used an O(n²) cache), as you can see in the memory usage plot below.

![nodangle_probing_final_space](https://user-images.githubusercontent.com/87138636/205981421-d9b2da1f-2942-4075-b1b0-7809aec31172.png)

I also profiled the program again to compare the percentages of the total execution time that can be attributed to the `getReactivityScore` function between this improvement and the original implementation. 

Current, improved version:

![getReactivityScore_profiling_current](https://user-images.githubusercontent.com/87138636/205981783-3a301582-bd20-4f77-af93-61ca6c27a496.png)

Original version:

![getReactivityScore_profiling_original](https://user-images.githubusercontent.com/87138636/205981846-95b012c6-147f-4cd2-ae79-0c72f82457bc.png)

As you can see in the partial profiling call graphs above, the `getReactivityScore` function now only accounts for 20.5% of the total execution time, compared to 93.6% when using the original implementation.
</details>

<details>
<summary>
Second idea (Now no longer necessary since we accept the minor numeric differences)

</summary>

~~Since my initial idea (see collapsed section) unfortunately didn't end up working due to the ever so slightly different score values,~~  I went ahead and adjusted the caching/lookup implementation to now fully precalculate the reactivity scores of all possible subsequences instead of adding them dynamically to the lookup array.

 Since I was able to transfer parts of the  algorithm of my initial idea, precalculating all possible scores now happens in a few milliseconds, which means that after the initial call to `getReactivityScore`, the function only performs lookups and doesn't need to do any conditional checks or index calculation like [before](https://github.com/jlab/fold-grammars/pull/54). The resulting speedup is noticeable, but unfortunately not quite as big as the speedup of my initial idea.

<details>
<summary>
Possible Explanation for the slow-down

</summary>

I assume this slow-down is causes by cache misses, which are very likely to occur here since the input subsequences (or rather their `i` and `j` positions) are somewhat random., meaning `getReactivityScore` doesn't receive continuous subsequences after a pattern like `Subsequence(0, 1)`, `Subsquence(0,2)`... As a result the next required score isn't part of the scores that were prefetched by the CPU during the last call to `getReactivityScore`, so they have to be flushed from the CPU cache and the required score has to be fetched from RAM which takes significantly longer. This wasn't a problem in my initial idea/implementation, because it only required and `n`-sized array, which can probably be entirely stored in the CPU cache and thus doesn't cause any cache misses when lookups are performed.
</details>

![time](https://user-images.githubusercontent.com/87138636/206326441-d50a1dde-c806-4b3c-adab-ca0c47cd5d0d.png)

As you can see, the execution time of the updated implementation (yellow line) sits somewhat in between the execution time of my initial implementation of this PR (green line)  and the currently used implementation from PR #56 (blue line). 

![space](https://user-images.githubusercontent.com/87138636/206326471-c8f52b33-9fcf-4905-a456-c8e234bb9bf8.png)

Since I now need to precalculate/store all possible scores again, the required memory equals the required memory of the currently used implementation again.

![Screenshot from 2022-12-08 01-33-51](https://user-images.githubusercontent.com/87138636/206327325-12bff78b-36cb-4557-9d3f-c40f0ba044e8.png)

The partial profiling call graph shows that now about 25% of the total execution time is spent in `getReactivityScore` (cf. percentages in first collapsed section). For reference, if we instantly return from `getReactivityScore`, it still accounts for about 19% of the total execution time of the program. So even though this Gapc compilation still spends a significant amount of time in this function, its impact on the total execution is almost as small as it could theoretically be.
</details>