### PR TITLE
Add Debian file to release

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,6 +52,6 @@ jobs:
     - uses: vishnudxb/cancel-workflow@v1.2
       if: failure()
       with:
-        repo: jlab/fold-grammars
+        repo: ${{ github.repository }}
         workflow_id: ${{ github.run_id }}
         access_token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,38 +6,21 @@ on:
       - "v*"
 
 jobs:
-  # release:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     upload_url: ${{ steps.create-release.outputs.upload_url }}
-  #   steps:
-  #     - name: Create Release
-  #       id: create-release
-  #       uses: actions/create-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tag_name: ${{ github.ref }}
-  #         release_name: Release ${{ github.ref }}
-  #         draft: false
-  #         prerelease: false
-
   build:
     runs-on: ubuntu-latest
-    # needs: release
     strategy:
       matrix:
         task:
           [
             [acms, aCMs],
-            # [shapes, RNAshapes],
-            # [pkiss, pKiss],
-            # [palikiss, pAliKiss],
-            # [rapidshapes, RapidShapes],
-            # [alishapes, RNAalishapes],
-            # [knotin, Knotinframe],
-            # [cofold, RNAcofold],
-            # [hybrid, RNAhybrid],
+            [shapes, RNAshapes],
+            [pkiss, pKiss],
+            [palikiss, pAliKiss],
+            [rapidshapes, RapidShapes],
+            [alishapes, RNAalishapes],
+            [knotin, Knotinframe],
+            [cofold, RNAcofold],
+            [hybrid, RNAhybrid],
           ]
     steps:
       - uses: actions/checkout@v4
@@ -81,13 +64,3 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           files: ${{ steps.build_deb.outputs.file_name }}
-      # - name: Upload Release Asset
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ github.token }}
-      #   with:
-      #     upload_url: ${{ needs.release.outputs.upload_url }}
-      #     asset_path: ./${{ steps.build_deb.outputs.file_name }}
-      #     asset_name: ${{ steps.build_deb.outputs.file_name }}
-      #     asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - main
+      - master
     tags:
       - '*'
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -41,7 +41,7 @@ jobs:
           ]
     steps:
       - name: Add PPA
-        run: sudo add-apt-repository ppa:~janssenlab/bellmansgapc
+        run: sudo add-apt-repository ppa:janssenlab/software
       - name: update apt
         run: sudo apt-get update
       - name: Install dependencies

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -43,6 +43,7 @@ jobs:
           body_path: samplescript_0.0.1_amd64.deb
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        continue-on-error: true
       - name: upload artifact
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -10,30 +10,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task: [default, shapes, pkiss, alishapes, palikiss, knotinframe]
+        app: [ aCMs, Knotinframe, Locomotif_wrapper, pAliKiss, pKiss, RapidShapes, RNAalishapes, RNAcofold, RNAhybrid, RNAShapes ]
     steps:
       - uses: actions/checkout@v4
-      - name: create sample script
-        id: create_script
+      - name: Create Tree
         run: |
-          mkdir -p .debpkg/usr/bin
-          mkdir -p .debpkg/usr/lib/samplescript
-          echo -e "echo sample" > .debpkg/usr/bin/samplescript
-          chmod +x .debpkg/usr/bin/samplescript
-          echo -e "a=1" > .debpkg/usr/lib/samplescript/samplescript.conf
-
-          # create DEBIAN directory if you want to add other pre/post scripts
-          mkdir -p .debpkg/DEBIAN
-          echo -e "echo postinst" > .debpkg/DEBIAN/postinst
-          chmod +x .debpkg/DEBIAN/postinst
+          make build-${{ matrix.app }} &&
+          cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task }}
+          mkdir -p .debpkg/usr/bin/
+          cp ${{ matrix.app }} .debpkg/usr/bin
+          cp x86_64-linux-gnu/* .debpkg/usr/bin
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:
-          package: samplescript
+          package: ${{ matrix.task }}
           package_root: .debpkg
-          maintainer: your_name
+          maintainer: To Be Determined
           version: v0.0.1 # refs/tags/v*.*.*
           arch: 'amd64'
-          depends: 'libc6 (>= 2.2.1), git'
+          depends: 'bellmansgapc (>= 2023.07.05), git, perl'
           desc: 'this is sample package.'
       - name: Create Release
         uses: ncipollo/release-action@v1.13.0
@@ -54,4 +52,5 @@ jobs:
         with:
           tag_name: v0.0.1
           files: ${{ steps.build_deb.outputs.file_name }}
+          # upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -33,7 +33,7 @@ jobs:
           make build-${{ matrix.task[0] }} &&
           cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
           mkdir -p .debpkg/usr/bin/
-          if [ -e ${{ matrix.task[1] }}]; then
+          if [ -e ${{ matrix.task[1] }} ]; then
             cp ${{ matrix.task[1] }} .debpkg/usr/bin
           fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -15,7 +15,7 @@ jobs:
         id: create-release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
@@ -83,7 +83,7 @@ jobs:
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./${{ steps.build_deb.outputs.file_name }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -42,10 +42,8 @@ jobs:
     steps:
       - name: Add PPA
         run: sudo add-apt-repository ppa:janssenlab/software
-      - name: update apt
-        run: sudo apt-get update
       - name: Install dependencies
-        run: sudo apt-get install gapc
+        run: sudo apt-get install bellmansgapc
 
       - name: Make Application
         run: make build-${{ matrix.task[0] }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -2,10 +2,8 @@ name: build
 
 on:
   push:
-    branches:
-      - master
     tags:
-      - 'v*.*.*'
+      - '*'
 
 jobs:
   build:
@@ -34,9 +32,24 @@ jobs:
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'
-          
-      - name: Commit build artefacts
-        uses: mutoco/commit-build-artefacts-action@0.5.1
+      - name: release
+        uses: actions/create-release@v1
+        id: create_release
         with:
-          # Source folder, defaults to ./build
-          source: ./
+          draft: false
+          prerelease: false
+          release_name: v0.0.1
+          tag_name: ${{ github.ref }}
+          body_path: samplescript_0.0.1_amd64.deb
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./samplescript_0.0.1_amd64.deb
+          asset_name: 'Sample Script Deb Package'
+          asset_content_type: application/vnd.debian.binary-package
+

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   upload:
+  steps:
     - name: Release
       needs: build 
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -39,4 +39,4 @@ jobs:
         uses: mutoco/commit-build-artefacts-action@0.5.1
         with:
           # Source folder, defaults to ./build
-          source: samplescript_0.0.1_amd64.deb
+          source: ./

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -15,6 +15,19 @@ jobs:
         task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapid-shapes, RapidShapes] , [alishapes, RNAalishapes],  [knotinframe, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
     steps:
       - uses: actions/checkout@v4
+      - name: update apt
+        run: sudo apt-get update
+      - name: Install dependencies
+        run: sudo apt-get install flex bison make libboost-all-dev libgsl-dev python3 python3-pip python3-biopython
+      - name: clone gapc
+        run: git clone -b master https://github.com/jlab/gapc.git $GITHUB_WORKSPACE/../gapc
+      - name: configure
+        run: cd $GITHUB_WORKSPACE/../gapc && ./configure
+      - name: make
+        run: cd $GITHUB_WORKSPACE/../gapc && make -j 2
+      - name: make install
+        run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
+
       - name: Create Tree
         run: |
           make build-${{ matrix.task[0] }} &&

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotinframe, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
+        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotin, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
     steps:
       - uses: actions/checkout@v4
       - name: update apt

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -47,19 +47,24 @@ jobs:
           maintainer: To Be Determined
           version: ${{  github.ref_name }}
           arch: 'amd64'
-          depends: 'bellmansgapc (>= 2023), git, perl'
-          desc: 'this is sample package.'
-      - name: Create Release
-        uses: ncipollo/release-action@v1.13.0
-        id: create_release
+          depends: 'perl'
+          desc: 'This is the ${{ matrix.task[1] }} package of fold-grammars.'
+      - uses: actions/upload-artifact@v3
         with:
-          tag: ${{  github.ref_name }}
-          allowUpdates: true
-          draft: true
-          prerelease: true
-          artifacts: ${{ steps.build_deb.outputs.file_name }}
-          replacesArtifacts: false
-          #body: This is the Body of the Release, how shall we dynamically set this? 
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        continue-on-error: true
+          name: artifacts
+          path: |
+            ./*.deb
+      # - name: Create Release
+      #   uses: ncipollo/release-action@v1.13.0
+      #   id: create_release
+      #   with:
+      #     tag: ${{  github.ref_name }}
+      #     allowUpdates: true
+      #     draft: true
+      #     prerelease: true
+      #     artifacts: ${{ steps.build_deb.outputs.file_name }}
+      #     replacesArtifacts: false
+      #     #body: This is the Body of the Release, how shall we dynamically set this? 
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #   continue-on-error: true

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -6,8 +6,25 @@ on:
       - '*'
 
 jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
   build:
     runs-on: ubuntu-latest
+    needs: release
     strategy:
       matrix:
         task: [ [acms, aCMs], [shapes, RNAshapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotin, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
@@ -25,7 +42,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/../gapc && make -j 2
       - name: make install
         run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
-
+      
       - name: Make Application
         run: make build-${{ matrix.task[0] }}
       - name: Package Application
@@ -51,22 +68,6 @@ jobs:
           depends: 'perl'
           desc: 'This is the ${{ matrix.task[1] }} package of fold-grammars.'
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: |
-            ./*.deb
-            
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
 
       - name: Upload Release Asset
         id: upload-release-asset 
@@ -74,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ./${{ steps.build_deb.outputs.file_name }}
           asset_name: ${{ steps.build_deb.outputs.file_name }}
           asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -37,4 +37,4 @@ jobs:
         uses: mutoco/commit-build-artefacts-action@0.5.1
         with:
           # Source folder, defaults to ./build
-          source: samplescript.deb
+          source: samplescript_0.0.1_amd64.deb

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -68,6 +68,7 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags/')
         with:
           tag_name: v0.0.1
+          append_body: true
           files: ${{ steps.build_deb.outputs.file_name }}
           # upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -36,8 +36,8 @@ jobs:
             cp ${{ matrix.task[1] }} .debpkg/usr/bin
           fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin
-          cp ../lib/foldGrammars .debpkg/usr/lib
-          cp ../lib/addRNAoptions.pl .debpkg/usr/bin
+          cp -r ../lib/foldGrammars .debpkg/usr/lib
+          cp ../addRNAoptions.pl .debpkg/usr/bin
           mkdir -p .debpkg/DEBIAN
       - uses: jiro4989/build-deb-action@v3
         id: build_deb

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -11,8 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
       - name: create sample script
         id: create_script
         run: |
@@ -55,5 +54,4 @@ jobs:
         with:
           tag_name: v0.0.1
           files: ${{ steps.build_deb.outputs.file_name }}
-          # upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -44,6 +44,7 @@ jobs:
           allowUpdates: true
           draft: true
           prerelease: true
+          artifacts: ${{ steps.build_deb.outputs.DEB_FILE }}
           bodyFile: ${{ steps.build_deb.outputs.DEB_FILE }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -41,6 +41,9 @@ jobs:
         id: create_release
         with:
           tag: refs/tags/v0.0.1
+          allowUpdates: true
+          draft: true
+          prerelease: true
           bodyFile: ${{ steps.build_deb.outputs.DEB_FILE }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -28,9 +28,9 @@ jobs:
       - name: make install
         run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
 
-      - name: Make each Application
+      - name: Make Application
         run: make build-${{ matrix.task[0] }} 
-      - name: Package each Application
+      - name: Package Application
         run: |
           cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
           mkdir -p .debpkg/usr/bin/
@@ -43,7 +43,7 @@ jobs:
         id: build_deb
         with:
           package: ${{ matrix.task[1] }}
-          package_root: .debpkg
+          package_root: ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}/.debpkg
           maintainer: To Be Determined
           version: v0.0.1 # refs/tags/v*.*.*
           arch: 'amd64'

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -37,6 +37,7 @@ jobs:
             cp ${{ matrix.task[1] }} .debpkg/usr/bin
           fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin
+          mkdir -p .debpkg/DEBIAN
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -36,7 +36,7 @@ jobs:
             cp ${{ matrix.task[1] }} .debpkg/usr/bin
           fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin
-          cp ../lib/foldGramars .debpkg/usr/lib
+          cp ../lib/foldGrammars .debpkg/usr/lib
           cp ../lib/addRNAoptions.pl .debpkg/usr/bin
           mkdir -p .debpkg/DEBIAN
       - uses: jiro4989/build-deb-action@v3

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -52,6 +52,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         # if: startsWith(github.ref, 'refs/tags/')
         with:
+          tag: v0.0.1
           files: ${{ steps.build_deb.outputs.DEB_FILE }}
           upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -28,7 +28,7 @@ jobs:
           package: samplescript
           package_root: .debpkg
           maintainer: your_name
-          version: v0.0.1 # ${{ github.ref }} # refs/tags/v*.*.*
+          version: ${{ github.ref }} # refs/tags/v*.*.*
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -6,17 +6,6 @@ on:
       - "v*"
 
 jobs:
-  upload:
-    runs-on: ubuntu-latest
-    needs: build 
-    steps:
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          files: '**/*.deb'
   # release:
   #   runs-on: ubuntu-latest
   #   outputs:
@@ -41,14 +30,14 @@ jobs:
         task:
           [
             [acms, aCMs],
-            [shapes, RNAshapes],
-            [pkiss, pKiss],
-            [palikiss, pAliKiss],
-            [rapidshapes, RapidShapes],
-            [alishapes, RNAalishapes],
-            [knotin, Knotinframe],
-            [cofold, RNAcofold],
-            [hybrid, RNAhybrid],
+            # [shapes, RNAshapes],
+            # [pkiss, pKiss],
+            # [palikiss, pAliKiss],
+            # [rapidshapes, RapidShapes],
+            # [alishapes, RNAalishapes],
+            # [knotin, Knotinframe],
+            # [cofold, RNAcofold],
+            # [hybrid, RNAhybrid],
           ]
     steps:
       - uses: actions/checkout@v4
@@ -85,6 +74,13 @@ jobs:
           arch: "amd64"
           depends: "perl"
           desc: "This is the ${{ matrix.task[1] }} package of fold-grammars."
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          files: ${{ steps.build_deb.outputs.file_name }}
       # - name: Upload Release Asset
       #   id: upload-release-asset
       #   uses: actions/upload-release-asset@v1

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [default, shapes, pkiss, alishapes, palikiss, knotinframe]
-        app: [ aCMs, Knotinframe, Locomotif_wrapper, pAliKiss, pKiss, RapidShapes, RNAalishapes, RNAcofold, RNAhybrid, RNAShapes ]
+        task: [ acms, shapes, pkiss, palikiss,  rapid-shapes, alishapes, knotinframe, cofold, hybrid ]
+        app: [ aCMs, RNAShapes, pKiss, pAliKiss,  RapidShapes, RNAalishapes, Knotinframe, RNAcofold, RNAhybrid ]
     steps:
       - uses: actions/checkout@v4
       - name: Create Tree
         run: |
-          make build-${{ matrix.app }} &&
-          cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task }}
+          make build-${{ matrix.task }} &&
+          cd ${{ github.workspace }}/Misc/Applications/${{ matrix.app }}
           mkdir -p .debpkg/usr/bin/
           cp ${{ matrix.app }} .debpkg/usr/bin
           cp x86_64-linux-gnu/* .debpkg/usr/bin

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -12,16 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [ acms, shapes, pkiss, palikiss,  rapid-shapes, alishapes, knotinframe, cofold, hybrid ]
-        app: [ aCMs, RNAShapes, pKiss, pAliKiss,  RapidShapes, RNAalishapes, Knotinframe, RNAcofold, RNAhybrid ]
+        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapid-shapes, RapidShapes] , [alishapes, RNAalishapes],  [knotinframe, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
     steps:
       - uses: actions/checkout@v4
       - name: Create Tree
         run: |
-          make build-${{ matrix.task }} &&
-          cd ${{ github.workspace }}/Misc/Applications/${{ matrix.app }}
+          make build-${{ matrix.task[0] }} &&
+          cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
           mkdir -p .debpkg/usr/bin/
-          cp ${{ matrix.app }} .debpkg/usr/bin
+          cp ${{ matrix.task[1] }} .debpkg/usr/bin
           cp x86_64-linux-gnu/* .debpkg/usr/bin
       - uses: jiro4989/build-deb-action@v3
         id: build_deb

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-    branches:
-      - master
     tags:
       - '*'
 
@@ -45,7 +43,7 @@ jobs:
           package: ${{ matrix.task[1] }}
           package_root: ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}/.debpkg
           maintainer: To Be Determined
-          version: v0.0.1 # refs/tags/v*.*.*
+          version: ${{  github.ref_name }}
           arch: 'amd64'
           depends: 'bellmansgapc (>= 2023), git, perl'
           desc: 'this is sample package.'
@@ -53,7 +51,7 @@ jobs:
         uses: ncipollo/release-action@v1.13.0
         id: create_release
         with:
-          tag: v0.0.1
+          tag: ${{  github.ref_name }}
           allowUpdates: true
           draft: true
           prerelease: true

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -52,7 +52,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         # if: startsWith(github.ref, 'refs/tags/')
         with:
-          tag: v0.0.1
+          tag_name: v0.0.1
           files: ${{ steps.build_deb.outputs.DEB_FILE }}
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          # upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     tags:
-      - '*'
+      - "v*"
 
 jobs:
   release:
@@ -27,7 +27,18 @@ jobs:
     needs: release
     strategy:
       matrix:
-        task: [ [acms, aCMs], [shapes, RNAshapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotin, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
+        task:
+          [
+            [acms, aCMs],
+            [shapes, RNAshapes],
+            [pkiss, pKiss],
+            [palikiss, pAliKiss],
+            [rapidshapes, RapidShapes],
+            [alishapes, RNAalishapes],
+            [knotin, Knotinframe],
+            [cofold, RNAcofold],
+            [hybrid, RNAhybrid],
+          ]
     steps:
       - uses: actions/checkout@v4
       - name: update apt
@@ -42,7 +53,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/../gapc && make -j 2
       - name: make install
         run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
-      
+
       - name: Make Application
         run: make build-${{ matrix.task[0] }}
       - name: Package Application
@@ -64,13 +75,12 @@ jobs:
           package_root: ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}/.debpkg
           maintainer: To Be Determined
           version: ${{  github.ref_name }}
-          arch: 'amd64'
-          depends: 'perl'
-          desc: 'This is the ${{ matrix.task[1] }} package of fold-grammars.'
-
+          arch: "amd64"
+          depends: "perl"
+          desc: "This is the ${{ matrix.task[1] }} package of fold-grammars."
 
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -48,13 +48,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
-      - name: upload artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
+          files: ${{ steps.build_deb.outputs.DEB_FILE }}
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.build_deb.outputs.DEB_FILE }}
-          asset_name: 'Sample Script Deb Package'
-          asset_content_type: application/vnd.debian.binary-package
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -32,7 +32,7 @@ jobs:
           package: samplescript
           package_root: .debpkg
           maintainer: your_name
-          version: refs/tags/v0.0.1 # refs/tags/v*.*.*
+          version: v0.0.1 # refs/tags/v*.*.*
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'
@@ -40,7 +40,7 @@ jobs:
         uses: ncipollo/release-action@v1.13.0
         id: create_release
         with:
-          tag: refs/tags/v0.0.1
+          tag: v0.0.1
           allowUpdates: true
           draft: true
           prerelease: true
@@ -50,7 +50,7 @@ jobs:
         continue-on-error: true
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        # if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ${{ steps.build_deb.outputs.DEB_FILE }}
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -44,6 +44,7 @@ jobs:
           prerelease: false
           release_name: ${{ github.ref }}
           tag_name: ${{ github.ref }}
+          body_path: ${{ steps.build_deb.outputs.DEB_FILE }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -7,15 +7,16 @@ on:
 
 jobs:
   upload:
-  steps:
-    - name: Release
-      needs: build 
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        files: '**/*.deb'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        needs: build 
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          files: '**/*.deb'
   # release:
   #   runs-on: ubuntu-latest
   #   outputs:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -47,7 +47,7 @@ jobs:
           maintainer: To Be Determined
           version: v0.0.1 # refs/tags/v*.*.*
           arch: 'amd64'
-          depends: 'bellmansgapc (>= 2023.07.05), git, perl'
+          depends: 'bellmansgapc (>= 2023), git, perl'
           desc: 'this is sample package.'
       - name: Create Release
         uses: ncipollo/release-action@v1.13.0

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotin, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
+        task: [ [acms, aCMs], [shapes, RNAshapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotin, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
     steps:
       - uses: actions/checkout@v4
       - name: update apt

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:
-          package: ${{ matrix.task }}
+          package: ${{ matrix.task[1] }}
           package_root: .debpkg
           maintainer: To Be Determined
           version: v0.0.1 # refs/tags/v*.*.*

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -28,9 +28,10 @@ jobs:
       - name: make install
         run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
 
-      - name: Create Tree
+      - name: Make each Application
+        run: make build-${{ matrix.task[0] }} 
+      - name: Package each Application
         run: |
-          make build-${{ matrix.task[0] }} &&
           cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
           mkdir -p .debpkg/usr/bin/
           if [ -e ${{ matrix.task[1] }} ]; then

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -27,15 +27,17 @@ jobs:
         run: cd $GITHUB_WORKSPACE/../gapc && sudo make install
 
       - name: Make Application
-        run: make build-${{ matrix.task[0] }} 
+        run: make build-${{ matrix.task[0] }}
       - name: Package Application
         run: |
           cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
-          mkdir -p .debpkg/usr/bin/
+          mkdir -p .debpkg/usr/{bin,lib}/
           if [ -e ${{ matrix.task[1] }} ]; then
             cp ${{ matrix.task[1] }} .debpkg/usr/bin
           fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin
+          cp ../lib/foldGramars .debpkg/usr/lib
+          cp ../lib/addRNAoptions.pl .debpkg/usr/bin
           mkdir -p .debpkg/DEBIAN
       - uses: jiro4989/build-deb-action@v3
         id: build_deb

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -40,6 +40,7 @@ jobs:
             [hybrid, RNAhybrid],
           ]
     steps:
+      - uses: actions/checkoutv4
       - name: Add PPA
         run: sudo add-apt-repository ppa:janssenlab/software
       - name: Install dependencies

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: create sample script
+        id: create_script
         run: |
           mkdir -p .debpkg/usr/bin
           mkdir -p .debpkg/usr/lib/samplescript
@@ -26,6 +27,7 @@ jobs:
           echo -e "echo postinst" > .debpkg/DEBIAN/postinst
           chmod +x .debpkg/DEBIAN/postinst
       - uses: jiro4989/build-deb-action@v3
+        id: build_deb
         with:
           package: samplescript
           package_root: .debpkg
@@ -40,9 +42,8 @@ jobs:
         with:
           draft: false
           prerelease: false
-          release_name: v0.0.1
+          release_name: ${{ github.ref }}
           tag_name: ${{ github.ref }}
-          body_path: samplescript_0.0.1_amd64.deb
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
@@ -52,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./samplescript_0.0.1_amd64.deb
+          asset_path: ${{ steps.build_deb.outputs.DEB_FILE }}
           asset_name: 'Sample Script Deb Package'
           asset_content_type: application/vnd.debian.binary-package
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -44,8 +44,8 @@ jobs:
           allowUpdates: true
           draft: true
           prerelease: true
-          artifacts: ${{ steps.build_deb.outputs.DEB_FILE }}
-          bodyFile: ${{ steps.build_deb.outputs.DEB_FILE }}
+          artifacts: ${{ steps.build_deb.outputs.file_name }}
+          bodyFile: ${{ steps.build_deb.outputs.file_name }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
@@ -54,6 +54,6 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags/')
         with:
           tag_name: v0.0.1
-          files: ${{ steps.build_deb.outputs.DEB_FILE }}
+          files: ${{ steps.build_deb.outputs.file_name }}
           # upload_url: ${{ steps.create_release.outputs.upload_url }}
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -14,7 +14,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-        files: **/*.deb
+        files: '**/*.deb'
   # release:
   #   runs-on: ubuntu-latest
   #   outputs:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -63,7 +63,7 @@ jobs:
           echo "${{ matrix.task[0] }} ${{ github.ref_name }} distributions; metadata"
           git log `git tag --sort=-v:refname | head -2`..`git tag --sort=-v:refname | head -1` --pretty="* %s"
           echo "-- maintainer <email> $(date +'%A, %d %B %G %R:%S +%Z')"
-          } >> changelog
+          } >> .debpkg/DEBIAN/changelog
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -40,7 +40,7 @@ jobs:
             [hybrid, RNAhybrid],
           ]
     steps:
-      - uses: actions/checkoutv4
+      - uses: actions/checkout@v4
       - name: Add PPA
         run: sudo add-apt-repository ppa:janssenlab/software
       - name: Install dependencies

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -60,7 +60,11 @@ jobs:
           cp -r ../lib/foldGrammars .debpkg/usr/lib
           cp ../addRNAoptions.pl .debpkg/usr/bin
           mkdir -p .debpkg/DEBIAN
-
+          {
+          echo "${{ matrix.task[0] }} ${{ github.ref_name }} distributions; metadata"
+          git log `git tag --sort=-v:refname | head -2`..`git tag --sort=-v:refname | head -1` --pretty="* %s"
+          echo "-- maintainer <email> $(date +'%A, %d %B %G %R:%S +%Z')"
+          } >> changelog
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -63,12 +63,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        # if: startsWith(github.ref, 'refs/tags/')
-        with:
-          tag_name: v0.0.1
-          append_body: true
-          files: ${{ steps.build_deb.outputs.file_name }}
-          # upload_url: ${{ steps.create_release.outputs.upload_url }}
-

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -33,7 +33,9 @@ jobs:
           make build-${{ matrix.task[0] }} &&
           cd ${{ github.workspace }}/Misc/Applications/${{ matrix.task[1] }}
           mkdir -p .debpkg/usr/bin/
-          cp ${{ matrix.task[1] }} .debpkg/usr/bin
+          if [ -e ${{ matrix.task[1] }}]; then
+            cp ${{ matrix.task[1] }} .debpkg/usr/bin
+          fi
           cp x86_64-linux-gnu/* .debpkg/usr/bin
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
@@ -54,7 +56,7 @@ jobs:
           draft: true
           prerelease: true
           artifacts: ${{ steps.build_deb.outputs.file_name }}
-          bodyFile: ${{ steps.build_deb.outputs.file_name }}
+          #body: This is the Body of the Release, how shall we dynamically set this? 
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -54,17 +54,21 @@ jobs:
           name: artifacts
           path: |
             ./*.deb
-      # - name: Create Release
-      #   uses: ncipollo/release-action@v1.13.0
-      #   id: create_release
-      #   with:
-      #     tag: ${{  github.ref_name }}
-      #     allowUpdates: true
-      #     draft: true
-      #     prerelease: true
-      #     artifacts: ${{ steps.build_deb.outputs.file_name }}
-      #     replacesArtifacts: false
-      #     #body: This is the Body of the Release, how shall we dynamically set this? 
-      #   env:
-      #     GITHUB_TOKEN: ${{ github.token }}
-      #   continue-on-error: true
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: ./changelog
+          draft: false
+          prerelease: false
+          
+      - name: Write upload_url to file
+        run: echo '${{ steps.create-release.outputs.upload_url }}' > upload_url.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: create-release
+          path: upload_url.txt

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -58,6 +58,7 @@ jobs:
           draft: true
           prerelease: true
           artifacts: ${{ steps.build_deb.outputs.file_name }}
+          replacesArtifacts: false
           #body: This is the Body of the Release, how shall we dynamically set this? 
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -6,25 +6,34 @@ on:
       - "v*"
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
-    steps:
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+  upload:
+    - name: Release
+      needs: build 
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        files: **/*.deb
+  # release:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #   steps:
+  #     - name: Create Release
+  #       id: create-release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ github.ref }}
+  #         release_name: Release ${{ github.ref }}
+  #         draft: false
+  #         prerelease: false
 
   build:
     runs-on: ubuntu-latest
-    needs: release
+    # needs: release
     strategy:
       matrix:
         task:
@@ -74,14 +83,13 @@ jobs:
           arch: "amd64"
           depends: "perl"
           desc: "This is the ${{ matrix.task[1] }} package of fold-grammars."
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./${{ steps.build_deb.outputs.file_name }}
-          asset_name: ${{ steps.build_deb.outputs.file_name }}
-          asset_content_type: application/vnd.debian.binary-package
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #   with:
+      #     upload_url: ${{ needs.release.outputs.upload_url }}
+      #     asset_path: ./${{ steps.build_deb.outputs.file_name }}
+      #     asset_name: ${{ steps.build_deb.outputs.file_name }}
+      #     asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: create sample script
+        run: |
+          mkdir -p .debpkg/usr/bin
+          mkdir -p .debpkg/usr/lib/samplescript
+          echo -e "echo sample" > .debpkg/usr/bin/samplescript
+          chmod +x .debpkg/usr/bin/samplescript
+          echo -e "a=1" > .debpkg/usr/lib/samplescript/samplescript.conf
+
+          # create DEBIAN directory if you want to add other pre/post scripts
+          mkdir -p .debpkg/DEBIAN
+          echo -e "echo postinst" > .debpkg/DEBIAN/postinst
+          chmod +x .debpkg/DEBIAN/postinst
+      - uses: jiro4989/build-deb-action@v3
+        with:
+          package: samplescript
+          package_root: .debpkg
+          maintainer: your_name
+          version: ${{ github.ref }} # refs/tags/v*.*.*
+          arch: 'amd64'
+          depends: 'libc6 (>= 2.2.1), git'
+          desc: 'this is sample package.'
+          
+      - name: Commit build artefacts
+        uses: mutoco/commit-build-artefacts-action@0.5.1
+        with:
+          # Source folder, defaults to ./build
+          source: samplescript.deb

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -32,7 +32,7 @@ jobs:
           package: samplescript
           package_root: .debpkg
           maintainer: your_name
-          version: ${{ github.ref }} # refs/tags/v*.*.*
+          version: refs/tags/v0.0.1 # refs/tags/v*.*.*
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'
@@ -42,8 +42,8 @@ jobs:
         with:
           draft: false
           prerelease: false
-          release_name: ${{ github.ref }}
-          tag_name: ${{ github.ref }}
+          release_name: refs/tags/v0.0.1
+          tag_name: refs/tags/v0.0.1
           body_path: ${{ steps.build_deb.outputs.DEB_FILE }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
     tags:
       - '*'
 

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -36,15 +36,12 @@ jobs:
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'
-      - name: release
-        uses: actions/create-release@v1
+      - name: Create Release
+        uses: ncipollo/release-action@v1.13.0
         id: create_release
         with:
-          draft: false
-          prerelease: false
-          release_name: refs/tags/v0.0.1
-          tag_name: refs/tags/v0.0.1
-          body_path: ${{ steps.build_deb.outputs.DEB_FILE }}
+          tag: refs/tags/v0.0.1
+          bodyFile: ${{ steps.build_deb.outputs.DEB_FILE }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -15,7 +15,7 @@ jobs:
         id: create-release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -30,7 +30,7 @@ jobs:
           package: samplescript
           package_root: .debpkg
           maintainer: your_name
-          version: ${{ github.ref }} # refs/tags/v*.*.*
+          version: v0.0.1 # ${{ github.ref }} # refs/tags/v*.*.*
           arch: 'amd64'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'this is sample package.'

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapid-shapes, RapidShapes] , [alishapes, RNAalishapes],  [knotinframe, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
+        task: [ [acms, aCMs], [shapes, RNAShapes], [pkiss, pKiss], [palikiss, pAliKiss],  [rapidshapes, RapidShapes] , [alishapes, RNAalishapes],  [knotinframe, Knotinframe], [cofold, RNAcofold], [hybrid, RNAhybrid] ]
     steps:
       - uses: actions/checkout@v4
       - name: update apt

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    needs: build 
     steps:
       - name: Release
-        needs: build 
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:

--- a/.github/workflows/test_packaging.yml
+++ b/.github/workflows/test_packaging.yml
@@ -39,6 +39,7 @@ jobs:
           cp -r ../lib/foldGrammars .debpkg/usr/lib
           cp ../addRNAoptions.pl .debpkg/usr/bin
           mkdir -p .debpkg/DEBIAN
+
       - uses: jiro4989/build-deb-action@v3
         id: build_deb
         with:
@@ -49,11 +50,13 @@ jobs:
           arch: 'amd64'
           depends: 'perl'
           desc: 'This is the ${{ matrix.task[1] }} package of fold-grammars.'
+
       - uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: |
             ./*.deb
+            
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1
@@ -61,14 +64,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body_path: ./changelog
+          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-          
-      - name: Write upload_url to file
-        run: echo '${{ steps.create-release.outputs.upload_url }}' > upload_url.txt
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: create-release
-          path: upload_url.txt
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./${{ steps.build_deb.outputs.file_name }}
+          asset_name: ${{ steps.build_deb.outputs.file_name }}
+          asset_content_type: application/vnd.debian.binary-package


### PR DESCRIPTION
Upon creating a new release this workflow will execute and add the packaged application to the release. They are incomplete debian packages and can't be uploaded to launchpad in their current state. 