### PR TITLE
remove double rna import from  ali_macrostate.gap

### DIFF
--- a/ali_macrostate.gap
+++ b/ali_macrostate.gap
@@ -5,8 +5,6 @@ import "Extensions/probabilities.hh"
 import "Extensions/typesRNAfolding.hh"
 import "Extensions/shapes.hh"
 
-input rna
-
 type base_t = extern
 type Rope = extern
 type shape_t = shape


### PR DESCRIPTION
removed double rna import, please check if this was there by mistake or is actually relevant, I'll remove it if the build does not finish successfully.